### PR TITLE
fix #11 automatically set version file on build

### DIFF
--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -1,9 +1,10 @@
 #define PREFIX GRAD
 #define MAINPREFIX x
 
-#define MAJOR 2
+#define MAJOR 0
 #define MINOR 0
 #define PATCHLVL 0
+#define COMMIT empty
 
 #define VERSION MAJOR.MINOR.PATCHLVL
 #define VERSION_AR MAJOR,MINOR,PATCHLVL

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -22,6 +22,8 @@ if [[ ! -f ${armakePath} ]]; then
 	exit 1
 fi
 
+bash "${toolsDir}/update-versionfile.sh"
+
 #copy to release directory
 releaseDir="$baseDir/release/$modname"
 mkdir -p "$releaseDir"

--- a/tools/update-versionfile.sh
+++ b/tools/update-versionfile.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+toolsDir=$(realpath "$(pwd)/$(dirname $0)")
+baseDir=`dirname "${toolsDir}"`
+
+echo "versionfile updater. looking for tag…"
+
+version=$(git describe --always --tag)
+
+versionfile="$baseDir/addons/main/script_mod.hpp"
+
+IFS='.-' read -ra versionbits <<< ${version}
+major=${versionbits[0]}
+minor=${versionbits[1]}
+patch=${versionbits[2]}
+commit=$(echo ${versionbits[4]} | tr -d g)
+
+re='^[0-9]+$'
+if ! [[ ${major} =~ $re && ${minor} =~ $re && ${patch} =~ $re ]] ; then
+   echo "not a release tag: '$version', not writing versionfile."
+   exit
+fi
+
+echo "we're on version $major.$minor.$patch, commit $commit . updating versionfile…"
+
+sed -ie "s/define MAJOR.*/define MAJOR $major/" ${versionfile}
+sed -ie "s/define MINOR.*/define MINOR $minor/" ${versionfile}
+sed -ie "s/define PATCHLVL.*/define PATCHLVL $patch/" ${versionfile}
+sed -ie "s/define COMMIT.*/define COMMIT $commit/" ${versionfile}
+
+echo "…done :)"


### PR DESCRIPTION
build script updates MAJOR / MINOR / PATCHLVL (based on last tag) before building; also adds COMMIT hash (which doesnt do atm… we might add it to the version string , like 2.1.0-abcdef  
:thinking: 

tag names that are not in the format `a.b.c` (with a/b/c integers values) will be ignored.
