### PR TITLE
cinematicSpec keybind

### DIFF
--- a/optionals/cinematicSpec/XEH_preInit.sqf
+++ b/optionals/cinematicSpec/XEH_preInit.sqf
@@ -1,0 +1,5 @@
+#include "\a3\editor_f\Data\Scripts\dikCodes.h"
+#include "script_component.hpp"
+SCRIPT(XEH_preInit);
+
+["Gruppe Adler","grad_cinematicSpec_toggle","Enter Cinematic Spectator",{true},"",[DIK_F2,[false,false,false]]] call CBA_fnc_addKeybind;

--- a/optionals/cinematicSpec/config.cpp
+++ b/optionals/cinematicSpec/config.cpp
@@ -22,3 +22,9 @@ class ACE_spectator_display {
 class ACE_spectator_interface {
 	onKeyDown = "_this call GRAD_cinematicSpec_fnc_chainHandlers";
 };
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        clientInit = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/optionals/cinematicSpec/functions/fn_ui_handleKeyDown.sqf
+++ b/optionals/cinematicSpec/functions/fn_ui_handleKeyDown.sqf
@@ -3,9 +3,14 @@
 
 private _key = param [1, 0];
 INFO_1("KeyDown, key %1", _key);
+
+private _keybind = ["Gruppe Adler","grad_cinematicSpec_toggle"] call CBA_fnc_getKeybind;
+if (isNil "_keybind") exitWith {};
+private _keycode = _keybind select 5 select 0;
+
 // Handle toggling camera
 if ([] call FUNC(isAceSpectator)) then {
-    if (_key == DIK_F2) exitWith {
+    if (_key == _keycode) exitWith {
         [] call FUNC(cam);
         true
     };


### PR DESCRIPTION
Adds keybinding to cinematicSpec.

This is somewhat dirty, as it doesn't use the actual event (just calls `{true}`). Instead fn_ui_handleKeyDown checks if the pressed key is the key that we bound,

Makes sense though in this context imo. Plus it's easier 😁 