### PR TITLE
experimental fix for ALK

### DIFF
--- a/addons/alk/CfgFunctions.hpp
+++ b/addons/alk/CfgFunctions.hpp
@@ -8,6 +8,7 @@ class CfgFunctions
 			file = "x\grad\addons\alk\functions";
 			class callbackSuccess {};
 			class condition {};
+			class resetBodyPartStatus {};
 			class treatArms {};
 			class treatLegs {};
 			class treatmentTime {};

--- a/addons/alk/functions/fn_resetBodyPartStatus.sqf
+++ b/addons/alk/functions/fn_resetBodyPartStatus.sqf
@@ -1,0 +1,13 @@
+params [["_target",objNull],["_bodyParts",[]]];
+
+private _status = _target getVariable ["ace_medical_bodyPartStatus",[0,0,0,0,0,0]];
+{
+    _id = [_x] call ace_medical_fnc_selectionNameToNumber;
+    if !(_id<0) then {
+        _status set [_id,0];
+    };
+
+    false
+} count _bodyParts;
+
+_target setVariable ["ace_medical_bodyPartStatus",_status,true];

--- a/addons/alk/functions/fn_treatArms.sqf
+++ b/addons/alk/functions/fn_treatArms.sqf
@@ -3,3 +3,9 @@ params ["_caller","_target"];
 _target setHitPointDamage ["HitHands",0];
 
 [_target, "activity_view", localize "STR_GRAD_ALK_LOG_ARMS", [[_caller, false, true] call ace_common_fnc_getName]] call ace_medical_fnc_addToLog;
+
+if (local _target) then {
+    [_target,["hand_l","hand_r"]] call grad_alk_fnc_resetBodyPartStatus;
+} else {
+    [_target,["hand_l","hand_r"]] remoteExec ["grad_alk_fnc_resetBodyPartStatus",_target,false];
+};

--- a/addons/alk/functions/fn_treatLegs.sqf
+++ b/addons/alk/functions/fn_treatLegs.sqf
@@ -3,3 +3,9 @@ params ["_caller","_target"];
 _target setHitPointDamage ["HitLegs", 0];
 
 [_target, "activity_view", localize "STR_GRAD_ALK_LOG_LEGS", [[_caller, false, true] call ace_common_fnc_getName]] call ace_medical_fnc_addToLog;
+
+if (local _target) then {
+    [_target,["leg_l","leg_r"]] call grad_alk_fnc_resetBodyPartStatus;
+} else {
+    [_target,["leg_l","leg_r"]] remoteExec ["grad_alk_fnc_resetBodyPartStatus",_target,false];
+};


### PR DESCRIPTION
Rein experimenteller Fix für #34 . Setzt die Werte der behandelten Gliedmaßen in der Variable "ace_medical_bodyPartStatus" zurück.

Keine Ahnung was diese Variable macht, aber es hört sich schonmal nicht verkehrt an. Im PAK-Heilungs-Code ([fnc_treatmentAdvanced_fullHealLocal](https://github.com/acemod/ACE3/blob/master/addons/medical/functions/fnc_treatmentAdvanced_fullHealLocal.sqf#L49)) wird die Variable komplett zurückgesetzt.