### PR TITLE
fix cfgPatches display name

### DIFF
--- a/addons/adminMessages/config.cpp
+++ b/addons/adminMessages/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main","A3_Ui_F"};

--- a/addons/alk/config.cpp
+++ b/addons/alk/config.cpp
@@ -4,7 +4,7 @@ class CfgPatches
 {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 0.1;
 		requiredAddons[] = {"grad_main","ace_medical"};

--- a/addons/ams/config.cpp
+++ b/addons/ams/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"ace_medical","grad_main"};

--- a/addons/brightFlares/config.cpp
+++ b/addons/brightFlares/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(COMPONENT);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main", "A3_Data_F", "A3_Weapons_F"};

--- a/addons/dynGroups/config.cpp
+++ b/addons/dynGroups/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main","A3_Ui_F","ace_common","cba_common"};

--- a/addons/equipment/config.cpp
+++ b/addons/equipment/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main","A3_weapons_f","rhsusf_infantry"};

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
     class ADDON {
         author = "$STR_grad_Author";
-        name = CSTRING(component);
+        name = QUOTE(ADDON);
         url = "$STR_grad_URL";
         units[] = {};
         weapons[] = {};

--- a/addons/main/stringtable.xml
+++ b/addons/main/stringtable.xml
@@ -9,9 +9,5 @@
             <English>https://www.gruppe-adler.de/international/</English>
             <German>https://www.gruppe-adler.de/</German>
         </Key>
-        <Key ID="STR_grad_Main_Component">
-            <English>Gruppe Adler Mod - Main Component</English>
-            <German>Gruppe Adler Mod - Main Component</German>
-        </Key>
     </Package>
 </Project>

--- a/addons/rebreatherOnLand/config.cpp
+++ b/addons/rebreatherOnLand/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main"};

--- a/addons/screenshotMode/config.cpp
+++ b/addons/screenshotMode/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main"};

--- a/addons/versionCheck/config.cpp
+++ b/addons/versionCheck/config.cpp
@@ -3,7 +3,7 @@
 class CfgPatches {
 	class ADDON {
 		author = "$STR_grad_Author";
-		name = CSTRING(component);
+		name = QUOTE(ADDON);
 		url = "$STR_grad_URL";
 		requiredVersion = 1.0;
 		requiredAddons[] = {"grad_main","ace_common"};


### PR DESCRIPTION
Sieht aus als wollten wir anfangs den Komponenten Displaynamen über Stringtable machen und habens dann vergessen.