### PR TITLE
Zeus fixes

### DIFF
--- a/addons/zeus/CfgEventHandlers.hpp
+++ b/addons/zeus/CfgEventHandlers.hpp
@@ -9,3 +9,9 @@ class Extended_PreInit_EventHandlers {
         init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};

--- a/addons/zeus/XEH_postInit.sqf
+++ b/addons/zeus/XEH_postInit.sqf
@@ -1,0 +1,19 @@
+/*
+    @Authors
+        Christian 'chris5790' Klemm
+    @Project
+        Gruppe Adler Mod
+    @Arguments
+        ?
+    @Return Value
+        ?
+    @Example
+        ?
+*/
+#include "script_component.hpp"
+
+if (isServer) then {
+    {
+        _x addCuratorPoints 1;
+    } forEach allCurators;
+};


### PR DESCRIPTION
Occasionally Arma fails to detect that Zeus points are disabled and prevents from moving objects. This adds Zeus points to bypass this issue.