### PR TITLE
close #105 add system for saving markers

### DIFF
--- a/addons/saveMarkers/$PBOPREFIX$
+++ b/addons/saveMarkers/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\grad\addons\saveMarkers

--- a/addons/saveMarkers/README.md
+++ b/addons/saveMarkers/README.md
@@ -1,0 +1,5 @@
+### saveMarkers
+Provides functionality for saving/loading markers across missions. This can be useful for players in commanding roles, who are able to prepare their strategic markers in advance to the mission.
+
+#### Maintainer(s)
+* McDiod

--- a/addons/saveMarkers/XEH_preClientInit.sqf
+++ b/addons/saveMarkers/XEH_preClientInit.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+["grad-saveMarkers",{
+    [] call FUNC(openDialog);
+},"all"] call CBA_fnc_registerChatCommand;

--- a/addons/saveMarkers/XEH_preClientInit.sqf
+++ b/addons/saveMarkers/XEH_preClientInit.sqf
@@ -1,5 +1,16 @@
 #include "script_component.hpp"
 
+
+private _title = "Save Markers";
+private _helpText = "
+If you slotted for a commanding role in an upcoming mission, this tool will come in handy. Save Markers allows you to save any markers from one mission and load them in another. That means you can just start a game in advance to the actual mission, draw your plan on the map, and save it for later. On gameday, you can load your markers instantly, saving valuable preparation time.<br/>
+<br/>
+You can open the Save Marker dialog with the chatcommand '#grad-saveMarkers', or by clicking here:<br/>
+<execute expression='openMap [false,false]; [grad_saveMarkers_fnc_loadDisplay,[]] call CBA_fnc_execNextFrame;'>[Open Save Markers]</execute>
+";
+
+[_title,_helpText] call EFUNC(ui,addHelpRecord);
+
 ["grad-saveMarkers",{
     [] call FUNC(openDialog);
 },"all"] call CBA_fnc_registerChatCommand;

--- a/addons/saveMarkers/XEH_preClientInit.sqf
+++ b/addons/saveMarkers/XEH_preClientInit.sqf
@@ -14,3 +14,5 @@ You can open the Save Marker dialog with the chatcommand '#grad-saveMarkers', or
 ["grad-saveMarkers",{
     [] call FUNC(openDialog);
 },"all"] call CBA_fnc_registerChatCommand;
+
+[] call FUNC(loadNotification);

--- a/addons/saveMarkers/XEH_preInit.sqf
+++ b/addons/saveMarkers/XEH_preInit.sqf
@@ -7,7 +7,7 @@
     "GRAD Save Markers",
     [
         [0,1,2],
-        ["never","first 5min of mission","always"],
+        ["never","first 10min of mission","always"],
         1
     ]
 ] call CBA_settings_fnc_init;

--- a/addons/saveMarkers/XEH_preInit.sqf
+++ b/addons/saveMarkers/XEH_preInit.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+
+[
+    QGVAR(setting_canBeOpened),
+    "LIST",
+    "Enabled",
+    "GRAD Save Markers",
+    [
+        [0,1,2],
+        ["never","first 5min of mission","always"],
+        1
+    ]
+] call CBA_settings_fnc_init;

--- a/addons/saveMarkers/cfgEventhandlers.hpp
+++ b/addons/saveMarkers/cfgEventhandlers.hpp
@@ -1,0 +1,6 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+        clientInit = QUOTE(call COMPILE_FILE(XEH_preClientInit));
+    };
+};

--- a/addons/saveMarkers/cfgFunctions.hpp
+++ b/addons/saveMarkers/cfgFunctions.hpp
@@ -1,0 +1,8 @@
+class cfgFunctions {
+	class grad_saveMarkers {
+		class common {
+			file = "x\grad\addons\saveMarkers\functions";
+
+		};
+	};
+};

--- a/addons/saveMarkers/cfgFunctions.hpp
+++ b/addons/saveMarkers/cfgFunctions.hpp
@@ -21,6 +21,7 @@ class cfgFunctions {
             class onMouseButtonUpMap {};
             class onSavesListSelChanged {};
             class onUnload {};
+            class openDialog {};
             class saveMarkers {};
             class setButtonEnabled {};
             class setListSelected {};

--- a/addons/saveMarkers/cfgFunctions.hpp
+++ b/addons/saveMarkers/cfgFunctions.hpp
@@ -3,6 +3,27 @@ class cfgFunctions {
 		class common {
 			file = "x\grad\addons\saveMarkers\functions";
 
+            class allMarkers {};
+            class createMarkerPreview {};
+            class findSaveInList {};
+            class getMarkerChannel {};
+            class getMarkersInArea {};
+            class loadDisplay {};
+            class loadMarkers {};
+            class onButtonDelete {};
+            class onButtonLoad {};
+            class onButtonSave {};
+            class onDraw {};
+            class onEditNameChanged {};
+            class onMouseButtonDownMap {};
+            class onMouseButtonUpMap {};
+            class onSavesListSelChanged {};
+            class onUnload {};
+            class saveMarkers {};
+            class setButtonEnabled {};
+            class setListSelected {};
+            class updateButtonSave {};
+            class updateSavesList {};
 		};
 	};
 };

--- a/addons/saveMarkers/cfgFunctions.hpp
+++ b/addons/saveMarkers/cfgFunctions.hpp
@@ -9,12 +9,14 @@ class cfgFunctions {
             class getMarkerChannel {};
             class getMarkersInArea {};
             class loadDisplay {};
+            class loadHelp {};
             class loadMarkers {};
             class onButtonDelete {};
             class onButtonLoad {};
             class onButtonSave {};
             class onDraw {};
             class onEditNameChanged {};
+            class onKeydownMap {};
             class onMouseButtonDownMap {};
             class onMouseButtonUpMap {};
             class onSavesListSelChanged {};
@@ -22,6 +24,7 @@ class cfgFunctions {
             class saveMarkers {};
             class setButtonEnabled {};
             class setListSelected {};
+            class toggleHelp {};
             class updateButtonSave {};
             class updateSavesList {};
 		};

--- a/addons/saveMarkers/cfgFunctions.hpp
+++ b/addons/saveMarkers/cfgFunctions.hpp
@@ -11,6 +11,7 @@ class cfgFunctions {
             class loadDisplay {};
             class loadHelp {};
             class loadMarkers {};
+            class loadNotification {};
             class onButtonDelete {};
             class onButtonLoad {};
             class onButtonSave {};

--- a/addons/saveMarkers/cfgNotifications.hpp
+++ b/addons/saveMarkers/cfgNotifications.hpp
@@ -1,0 +1,11 @@
+
+class cfgNotifications {
+    class GVAR(notification) {
+        title = "%1";
+        /* iconPicture = "\A3\ui_f\data\map\markers\military\triangle_CA.paa"; */
+        iconPicture = "\x\grad\addons\ui\dialog\logo_128.paa";        
+        description = "%2";
+        duration = 5;
+        priority = 0;
+    };
+};

--- a/addons/saveMarkers/config.cpp
+++ b/addons/saveMarkers/config.cpp
@@ -14,5 +14,6 @@ class CfgPatches {
 	};
 };
 
+#include "cfgEventhandlers.hpp"
 #include "cfgFunctions.hpp"
 #include "ui\dialog.hpp"

--- a/addons/saveMarkers/config.cpp
+++ b/addons/saveMarkers/config.cpp
@@ -14,6 +14,7 @@ class CfgPatches {
 	};
 };
 
+#include "cfgNotifications.hpp"
 #include "cfgEventhandlers.hpp"
 #include "cfgFunctions.hpp"
 #include "ui\dialog.hpp"

--- a/addons/saveMarkers/config.cpp
+++ b/addons/saveMarkers/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		author = "$STR_grad_Author";
+		name = QUOTE(ADDON);
+		url = "$STR_grad_URL";
+		requiredVersion = 1.0;
+		requiredAddons[] = {"grad_main"};
+		units[] = {};
+		weapons[] = {};
+		VERSION_CONFIG;
+        authors[] = {"McDiod"};
+	};
+};
+
+#include "cfgFunctions.hpp"
+#include "ui\dialog.hpp"

--- a/addons/saveMarkers/functions/fn_allMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_allMarkers.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+allMapMarkers select {_x find "_USER_DEFINED" == 0 && {getMarkerType _x != ""}}

--- a/addons/saveMarkers/functions/fn_allMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_allMarkers.sqf
@@ -1,3 +1,11 @@
 #include "script_component.hpp"
 
-allMapMarkers select {_x find "_USER_DEFINED" == 0 && {getMarkerType _x != ""}}
+params [["_selectEditorMarkers",false]];
+
+private _allMarkers = allMapMarkers select {!((getMarkerType _x) in ["","Empty"]) && {(_x find "ACE_BFT_") != 0}};
+
+if (!_selectEditorMarkers) then {
+    _allMarkers = _allMarkers select {_x find "_USER_DEFINED" == 0};
+};
+
+_allMarkers

--- a/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
+++ b/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
@@ -22,7 +22,7 @@ GVAR(previewMarkers) = [];
 
     private _markerID = format ["_USER_DEFINED #-1/%1/%2",_forEachIndex,_channel];
 
-    _marker = createMarkerLocal [_markerID,_pos];
+    private _marker = createMarkerLocal [_markerID,_pos];
     _marker setMarkerAlphaLocal _alpha;
     _marker setMarkerBrushLocal _brush;
     _marker setMarkerColorLocal _color;

--- a/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
+++ b/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
@@ -20,7 +20,7 @@ GVAR(previewMarkers) = [];
         "_channel"
     ];
 
-    _markerID = format ["_USER_DEFINED #-1/%1/%2",_forEachIndex,_channel];
+    private _markerID = format ["_USER_DEFINED #-1/%1/%2",_forEachIndex,_channel];
 
     _marker = createMarkerLocal [_markerID,_pos];
     _marker setMarkerAlphaLocal _alpha;

--- a/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
+++ b/addons/saveMarkers/functions/fn_createMarkerPreview.sqf
@@ -1,0 +1,38 @@
+#include "script_component.hpp"
+
+params [["_markersData",[]]];
+
+private _previewMarkers = missionNamespace getVariable [QGVAR(previewMarkers),[]];
+{deleteMarker _x} forEach _previewMarkers;
+
+GVAR(previewMarkers) = [];
+{
+    _x params [
+        "_alpha",
+        "_brush",
+        "_color",
+        "_dir",
+        "_pos",
+        "_shape",
+        "_size",
+        "_text",
+        "_type",
+        "_channel"
+    ];
+
+    _markerID = format ["_USER_DEFINED #-1/%1/%2",_forEachIndex,_channel];
+
+    _marker = createMarkerLocal [_markerID,_pos];
+    _marker setMarkerAlphaLocal _alpha;
+    _marker setMarkerBrushLocal _brush;
+    _marker setMarkerColorLocal _color;
+    _marker setMarkerDirLocal _dir;
+    _marker setMarkerPosLocal _pos;
+    _marker setMarkerShapeLocal _shape;
+    _marker setMarkerSizeLocal _size;
+    _marker setMarkerTextLocal _text;
+    _marker setMarkerTypeLocal _type;
+
+    GVAR(previewMarkers) pushBack _marker;
+
+} forEach _markersData;

--- a/addons/saveMarkers/functions/fn_findSaveInList.sqf
+++ b/addons/saveMarkers/functions/fn_findSaveInList.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+
+params ["_editText","_worldName"];
+
+private _display = findDisplay IDD_SAVEMARKERS;
+private _ctrlSavesList  = _display displayCtrl IDC_SAVESLIST;
+
+private _return = -1;
+
+for "_i" from 0 to ((lnbSize _ctrlSavesList) select 0)-1 do {
+    if ((_ctrlSavesList lnbText [_i,0]) == _editText && {(_ctrlSavesList lnbText [_i,1]) == _worldName}) exitWith {
+        _return = _i
+    };
+};
+
+_return

--- a/addons/saveMarkers/functions/fn_getMarkerChannel.sqf
+++ b/addons/saveMarkers/functions/fn_getMarkerChannel.sqf
@@ -1,0 +1,10 @@
+#include "script_component.hpp"
+
+params ["_marker"];
+
+if (_marker find "_USER_DEFINED" != 0) exitWith {0};
+
+(_marker splitString " ") params ["",["_markerData",""]];
+(_markerData splitString "/") params ["","",["_markerChannel",0]];
+
+_markerChannel

--- a/addons/saveMarkers/functions/fn_getMarkersInArea.sqf
+++ b/addons/saveMarkers/functions/fn_getMarkersInArea.sqf
@@ -1,10 +1,8 @@
 #include "script_component.hpp"
 
-params ["_area"];
+params ["_area",["_selectEditorMarkers",false]];
 
-private _allUserMarkers = allMapMarkers select {_x find "_USER_DEFINED" == 0 && {getMarkerType _x != ""}};
-
-private _markersInArea = _allUserMarkers select {
+private _markersInArea = ([_selectEditorMarkers] call FUNC(allMarkers)) select {
     (getMarkerPos _x) inArea _area
 };
 

--- a/addons/saveMarkers/functions/fn_getMarkersInArea.sqf
+++ b/addons/saveMarkers/functions/fn_getMarkersInArea.sqf
@@ -1,0 +1,11 @@
+#include "script_component.hpp"
+
+params ["_area"];
+
+private _allUserMarkers = allMapMarkers select {_x find "_USER_DEFINED" == 0 && {getMarkerType _x != ""}};
+
+private _markersInArea = _allUserMarkers select {
+    (getMarkerPos _x) inArea _area
+};
+
+_markersInArea

--- a/addons/saveMarkers/functions/fn_loadDisplay.sqf
+++ b/addons/saveMarkers/functions/fn_loadDisplay.sqf
@@ -2,7 +2,7 @@
 #include "..\ui\defines.hpp"
 
 
-GVAR(selectedMarkers) = [] call FUNC(allMarkers);
+GVAR(selectedMarkers) = [];
 GVAR(previewMarkers) = [];
 
 private _display = (findDisplay 46) createDisplay QGVAR(RscDisplayMarkers);
@@ -15,14 +15,9 @@ _mapCtrl ctrlAddEventHandler ["Draw",FUNC(onDraw)];
 _mapCtrl ctrlMapAnimAdd [0,0.8,[worldSize/2,worldSize/2]];
 ctrlMapAnimCommit _mapCtrl;
 
-// select all event
-_mapCtrl ctrlAddEventHandler ["KeyDown",{
-    params ["","_key","","_ctrl"];
-    if (_ctrl && {_key == 30}) then {
-        GVAR(selectedMarkers) = [] call FUNC(allMarkers);
-        [] call FUNC(updateButtonSave);
-    };
-}];
+_mapCtrl ctrlAddEventHandler ["KeyDown",FUNC(onKeydownMap)];
+
+onMapSingleClick "true";
 
 // buttons =====================================================================
 private _ctrlButtonSave = _display displayCtrl IDC_BUTTONSAVE;
@@ -48,3 +43,19 @@ _ctrlSavesList ctrlAddEventHandler ["lbSelChanged",FUNC(onSavesListSelChanged)];
 private _ctrlEditName = _display displayCtrl IDC_EDITNAME;
 // execNextFrame here, because handler fires before backspace deletes a character
 _ctrlEditName ctrlAddEventHandler ["keyDown",{[FUNC(onEditNameChanged),_this] call CBA_fnc_execNextFrame}];
+
+// help ========================================================================
+private _ctrlHelp = _display displayCtrl IDC_HELP;
+_ctrlHelp ctrlShow false;
+_ctrlHelp ctrlShow true;
+
+// add this EH to help as well in case user clicks on help
+_ctrlHelp ctrlAddEventHandler ["KeyDown",FUNC(onKeydownMap)];
+
+private _ctrlHelpText = _display displayCtrl IDC_HELP_TEXT;
+[_ctrlHelpText] call FUNC(loadHelp);
+
+private _ctrlHelpPos = ctrlPosition _ctrlHelp;
+_ctrlHelpPos set [3,[1 * Y_FACTOR,22.2 * Y_FACTOR] select (missionNamespace getVariable [QGVAR(helpEnabled),false])];
+_ctrlHelp ctrlSetPosition _ctrlHelpPos;
+_ctrlHelp ctrlCommit -1;

--- a/addons/saveMarkers/functions/fn_loadDisplay.sqf
+++ b/addons/saveMarkers/functions/fn_loadDisplay.sqf
@@ -1,0 +1,50 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+
+GVAR(selectedMarkers) = [] call FUNC(allMarkers);
+GVAR(previewMarkers) = [];
+
+private _display = (findDisplay 46) createDisplay QGVAR(RscDisplayMarkers);
+
+// map =========================================================================
+private _mapCtrl = _display displayCtrl IDC_MAP;
+_mapCtrl ctrlAddEventHandler ["MouseButtonDown",FUNC(onMouseButtonDownMap)];
+_mapCtrl ctrlAddEventHandler ["MouseButtonUp",FUNC(onMouseButtonUpMap)];
+_mapCtrl ctrlAddEventHandler ["Draw",FUNC(onDraw)];
+_mapCtrl ctrlMapAnimAdd [0,0.8,[worldSize/2,worldSize/2]];
+ctrlMapAnimCommit _mapCtrl;
+
+// select all event
+_mapCtrl ctrlAddEventHandler ["KeyDown",{
+    params ["","_key","","_ctrl"];
+    if (_ctrl && {_key == 30}) then {
+        GVAR(selectedMarkers) = [] call FUNC(allMarkers);
+        [] call FUNC(updateButtonSave);
+    };
+}];
+
+// buttons =====================================================================
+private _ctrlButtonSave = _display displayCtrl IDC_BUTTONSAVE;
+_ctrlButtonSave ctrlAddEventHandler ["buttonClick",FUNC(onButtonSave)];
+
+private _ctrlButtonDelete = _display displayCtrl IDC_BUTTONDELETE;
+_ctrlButtonDelete ctrlAddEventHandler ["buttonClick",FUNC(onButtonDelete)];
+
+private _ctrlButtonLoad = _display displayCtrl IDC_BUTTONLOAD;
+_ctrlButtonLoad ctrlAddEventHandler ["buttonClick",FUNC(onButtonLoad)];
+
+[IDC_BUTTONDELETE,false] call FUNC(setButtonEnabled);
+[IDC_BUTTONLOAD,false] call FUNC(setButtonEnabled);
+[IDC_BUTTONSAVE,false] call FUNC(setButtonEnabled);
+
+// saves list ==================================================================
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+_ctrlSavesList ctrlAddEventHandler ["lbSelChanged",FUNC(onSavesListSelChanged)];
+
+[_display] call FUNC(updateSavesList);
+
+// edit name ===================================================================
+private _ctrlEditName = _display displayCtrl IDC_EDITNAME;
+// execNextFrame here, because handler fires before backspace deletes a character
+_ctrlEditName ctrlAddEventHandler ["keyDown",{[FUNC(onEditNameChanged),_this] call CBA_fnc_execNextFrame}];

--- a/addons/saveMarkers/functions/fn_loadHelp.sqf
+++ b/addons/saveMarkers/functions/fn_loadHelp.sqf
@@ -14,5 +14,5 @@ Press <t color='%1'>[H]</t> to toggle help.<br/>
 <br/>
 <t color='%1'>[alt]</t> - Hold while selecting to enable selection of editor or script created markers.<br/>
 <br/>
-<t color='%1'>[shift]</t> - Hold while selecting remove markers from selection.<br/>
+<t color='%1'>[shift]</t> - Hold while selecting to remove markers from selection.<br/>
 </t>",HIGHLIGHT_COLOR];

--- a/addons/saveMarkers/functions/fn_loadHelp.sqf
+++ b/addons/saveMarkers/functions/fn_loadHelp.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+#define HIGHLIGHT_COLOR "#2eea54"
+
+params ["_ctrlHelpText"];
+
+_ctrlHelpText ctrlSetStructuredText parseText format ["<t size='0.8'>
+Press <t color='%1'>[H]</t> to toggle help.<br/>
+<br/>
+<t color='%1'>select markers</t> - Drag with left mouse button to select markers.<br/>
+<br/>
+<t color='%1'>[ctrl + A]</t> - Select all markers.<br/>
+<br/>
+<t color='%1'>[ctrl]</t> - Hold while selecting to add to selection.<br/>
+<br/>
+<t color='%1'>[alt]</t> - Hold while selecting to enable selection of editor or script created markers.<br/>
+<br/>
+<t color='%1'>[shift]</t> - Hold while selecting remove markers from selection.<br/>
+</t>",HIGHLIGHT_COLOR];

--- a/addons/saveMarkers/functions/fn_loadMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_loadMarkers.sqf
@@ -1,0 +1,32 @@
+#include "script_component.hpp"
+
+params ["_saveName","_mapName",["_markersData",[]]];
+
+{
+    _x params [
+        "_alpha",
+        "_brush",
+        "_color",
+        "_dir",
+        "_pos",
+        "_shape",
+        "_size",
+        "_text",
+        "_type",
+        "_channel"
+    ];
+
+    _markerID = format ["_USER_DEFINED #-1%1%2/%3/%4",_saveName,_mapName,_forEachIndex,_channel];
+
+    _marker = createMarker [_markerID,_pos];
+    _marker setMarkerAlpha _alpha;
+    _marker setMarkerBrush _brush;
+    _marker setMarkerColor _color;
+    _marker setMarkerDir _dir;
+    _marker setMarkerPos _pos;
+    _marker setMarkerShape _shape;
+    _marker setMarkerSize _size;
+    _marker setMarkerText _text;
+    _marker setMarkerType _type;
+
+} forEach _markersData;

--- a/addons/saveMarkers/functions/fn_loadMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_loadMarkers.sqf
@@ -18,7 +18,7 @@ params ["_saveName","_mapName",["_markersData",[]]];
 
     _markerID = format ["_USER_DEFINED #-1%1%2/%3/%4",_saveName,_mapName,_forEachIndex,_channel];
 
-    _marker = createMarker [_markerID,_pos];
+    private _marker = createMarker [_markerID,_pos];
     _marker setMarkerAlpha _alpha;
     _marker setMarkerBrush _brush;
     _marker setMarkerColor _color;

--- a/addons/saveMarkers/functions/fn_loadMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_loadMarkers.sqf
@@ -16,7 +16,7 @@ params ["_saveName","_mapName",["_markersData",[]]];
         "_channel"
     ];
 
-    _markerID = format ["_USER_DEFINED #-1%1%2/%3/%4",_saveName,_mapName,_forEachIndex,_channel];
+    private _markerID = format ["_USER_DEFINED #-1%1%2/%3/%4",_saveName,_mapName,_forEachIndex,_channel];
 
     private _marker = createMarker [_markerID,_pos];
     _marker setMarkerAlpha _alpha;

--- a/addons/saveMarkers/functions/fn_loadNotification.sqf
+++ b/addons/saveMarkers/functions/fn_loadNotification.sqf
@@ -1,0 +1,17 @@
+/*  Displays notification on missionstart if player can load a marker set.
+*   Called from XEH_preClientInit.sqf
+*/
+
+#include "script_component.hpp"
+
+private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
+if (isNil "_saveMarkersData") exitWith {};
+
+private _hasWorldSaveData = _saveMarkersData findIf {worldName isEqualTo (_x select 1)};
+if (_hasWorldSaveData < 0) exitWith {};
+
+[{!isNull (findDisplay 46)},{
+    [{
+        [QGVAR(notification),["GRAD SAVE MARKERS","You have markers that can now be loaded."]] call bis_fnc_showNotification;
+    },[],10] call CBA_fnc_waitAndExecute;
+},[]] call CBA_fnc_waitUntilAndExecute;

--- a/addons/saveMarkers/functions/fn_onButtonDelete.sqf
+++ b/addons/saveMarkers/functions/fn_onButtonDelete.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_ctrlButtonDelete"];
+
+private _display = ctrlParent _ctrlButtonDelete;
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+private _ctrlEditName = _display displayCtrl IDC_EDITNAME;
+
+private _saveID = _ctrlSavesList lnbValue [lnbCurSelRow _ctrlSavesList,0];
+
+private _saveMarkersData = profileNamespace getVariable [QGVAR(saveData),[]];
+_saveMarkersData deleteAt _saveID;
+saveProfileNamespace;
+
+[_display] call FUNC(updateSavesList);
+_ctrlSavesList lnbSetCurSelRow -1;
+_ctrlEditName ctrlSetText "";

--- a/addons/saveMarkers/functions/fn_onButtonLoad.sqf
+++ b/addons/saveMarkers/functions/fn_onButtonLoad.sqf
@@ -16,4 +16,6 @@ private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
 
 [_saveName,_mapName,_markersData] call FUNC(loadMarkers);
 
+(format ["grad-saveMarkers: %1 just loaded his marker set %2.",profileName,_saveName]) remoteExec ["systemChat",0,false];
+
 _ctrlSavesList lnbSetCurSelRow -1;

--- a/addons/saveMarkers/functions/fn_onButtonLoad.sqf
+++ b/addons/saveMarkers/functions/fn_onButtonLoad.sqf
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_ctrlButtonLoad"];
+
+private _display = ctrlParent _ctrlButtonLoad;
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+
+private _selID = lnbCurSelRow _ctrlSavesList;
+if (_selID < 0) exitWith {};
+
+private _dataID = _ctrlSavesList lnbValue [_selID,0];
+private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
+
+(_saveMarkersData select _dataID) params ["_saveName","_mapName",["_markersData",[]]];
+
+[_saveName,_mapName,_markersData] call FUNC(loadMarkers);
+
+_ctrlSavesList lnbSetCurSelRow -1;

--- a/addons/saveMarkers/functions/fn_onButtonSave.sqf
+++ b/addons/saveMarkers/functions/fn_onButtonSave.sqf
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_ctrlButtonSave"];
+
+if (count GVAR(selectedMarkers) == 0) exitWith {};
+
+private _display = ctrlParent _ctrlButtonSave;
+private _ctrlEdit = _display displayCtrl IDC_EDITNAME;
+
+private _saveAs = ctrlText _ctrlEdit;
+
+[_saveAs,worldName,GVAR(selectedMarkers)] call FUNC(saveMarkers);
+[_display] call FUNC(updateSavesList);
+[_display,-1] call FUNC(setListSelected);

--- a/addons/saveMarkers/functions/fn_onDraw.sqf
+++ b/addons/saveMarkers/functions/fn_onDraw.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+
+params ["_mapCtrl"];
+
+{
+    _mapCtrl drawIcon [
+        "\A3\ui_f\data\map\diary\icons\diaryAssignTask_ca.paa",
+        [0,1,0,1],
+        getMarkerPos _x,
+        12,
+        12,
+        0
+    ]
+} forEach GVAR(selectedMarkers);
+
+{
+    _textPos = _mapCtrl ctrlMapScreenToWorld ((_mapCtrl ctrlMapWorldToScreen (getMarkerPos _x)) apply {_x + 0.02});
+
+    _mapCtrl drawIcon [
+        "\A3\ui_f\data\map\markers\system\dummy_ca.paa",
+        [0,1,0,1],
+        _textPos,
+        12,
+        12,
+        0,
+        "preview",
+        0,
+        0.04
+    ]
+} forEach GVAR(previewMarkers);

--- a/addons/saveMarkers/functions/fn_onEditNameChanged.sqf
+++ b/addons/saveMarkers/functions/fn_onEditNameChanged.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_ctrlEditName"];
+
+private _display = findDisplay IDD_SAVEMARKERS;
+[_display] call FUNC(updateButtonSave);
+
+// second param is only nil if this function was called by an actual keystroke (and not by clicking on a save from list)
+if (isNil {_this param [1]}) exitWith {};
+
+if (isNil "_ctrlEditName") then {
+    _ctrlEditName = _display displayCtrl IDC_EDITNAME;
+};
+
+private _editText = ctrlText _ctrlEditName;
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+_ctrlSavesList lnbSetCurSelRow ([_editText,worldName] call FUNC(findSaveInList));

--- a/addons/saveMarkers/functions/fn_onKeydownMap.sqf
+++ b/addons/saveMarkers/functions/fn_onKeydownMap.sqf
@@ -1,0 +1,14 @@
+#include "script_component.hpp"
+
+params ["","_key","","_ctrl","_alt"];
+
+// H key
+if (_key == 35) exitWith {
+    [] call FUNC(toggleHelp);
+};
+
+// A key
+if (_ctrl && {_key == 30}) exitWith {
+    GVAR(selectedMarkers) = [_alt] call FUNC(allMarkers);
+    [] call FUNC(updateButtonSave);
+};

--- a/addons/saveMarkers/functions/fn_onMouseButtonDownMap.sqf
+++ b/addons/saveMarkers/functions/fn_onMouseButtonDownMap.sqf
@@ -1,0 +1,21 @@
+#include "script_component.hpp"
+
+params ["_mapCtrl","_mouseButton","_mouseX","_mouseY"];
+
+// leftclick only
+if (_mouseButton != 0) exitWith {};
+
+if (!isNil QGVAR(selectDrawEH)) exitWith {};
+
+GVAR(mouseDragStart) = _mapCtrl ctrlMapScreenToWorld [_mouseX,_mouseY];
+GVAR(selectDrawEH) = _mapCtrl ctrlAddEventHandler ["draw",{
+    params ["_mapCtrl"];
+
+    (_mapCtrl ctrlMapScreenToWorld getMousePosition) params ["_currentMouseX","_currentMouseY"];
+    GVAR(mouseDragStart) params ["_startMouseX","_startMouseY"];
+
+    _halfDeltaX = (_currentMouseX - _startMouseX)/2;
+    _halfDeltaY = (_currentMouseY - _startMouseY)/2;
+
+    _mapCtrl drawRectangle [[_startMouseX + _halfDeltaX,_startMouseY + _halfDeltaY],_halfDeltaX,_halfDeltaY,0,[0,0,0,1],""];
+}];

--- a/addons/saveMarkers/functions/fn_onMouseButtonUpMap.sqf
+++ b/addons/saveMarkers/functions/fn_onMouseButtonUpMap.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+
+params ["_mapCtrl","_mouseButton","_mouseX","_mouseY","","_ctrlDown"];
+
+// leftclick only
+if (_mouseButton != 0) exitWith {};
+
+if (isNil QGVAR(selectDrawEH)) exitWith {};
+
+_mapCtrl ctrlRemoveEventHandler ["draw",GVAR(selectDrawEH)];
+GVAR(selectDrawEH) = nil;
+
+GVAR(mouseDragStart) params ["_startMouseX","_startMouseY"];
+GVAR(mouseDragStart) = nil;
+(_mapCtrl ctrlMapScreenToWorld [_mouseX,_mouseY]) params ["_endMouseX","_endMouseY"];
+
+private _halfDeltaX = (_endMouseX - _startMouseX)/2;
+private _halfDeltaY = (_endMouseY - _startMouseY)/2;
+
+private _selectedArea = [[_startMouseX + _halfDeltaX,_startMouseY + _halfDeltaY],_halfDeltaX,_halfDeltaY,0,true];
+private _selectedMarkers = [_selectedArea] call FUNC(getMarkersInArea);
+
+if (_ctrlDown) then {
+    GVAR(selectedMarkers) = GVAR(selectedMarkers) + _selectedMarkers;
+} else {
+    GVAR(selectedMarkers) = _selectedMarkers;
+};
+
+[] call FUNC(updateButtonSave);
+[nil,-1] call FUNC(setListSelected);

--- a/addons/saveMarkers/functions/fn_onMouseButtonUpMap.sqf
+++ b/addons/saveMarkers/functions/fn_onMouseButtonUpMap.sqf
@@ -1,6 +1,6 @@
 #include "script_component.hpp"
 
-params ["_mapCtrl","_mouseButton","_mouseX","_mouseY","","_ctrlDown"];
+params ["_mapCtrl","_mouseButton","_mouseX","_mouseY","_shiftDown","_ctrlDown","_altDown"];
 
 // leftclick only
 if (_mouseButton != 0) exitWith {};
@@ -18,12 +18,16 @@ private _halfDeltaX = (_endMouseX - _startMouseX)/2;
 private _halfDeltaY = (_endMouseY - _startMouseY)/2;
 
 private _selectedArea = [[_startMouseX + _halfDeltaX,_startMouseY + _halfDeltaY],_halfDeltaX,_halfDeltaY,0,true];
-private _selectedMarkers = [_selectedArea] call FUNC(getMarkersInArea);
+private _selectedMarkers = [_selectedArea,_altDown || _shiftDown] call FUNC(getMarkersInArea);
 
-if (_ctrlDown) then {
-    GVAR(selectedMarkers) = GVAR(selectedMarkers) + _selectedMarkers;
+if (_shiftDown) then {
+    GVAR(selectedMarkers) = GVAR(selectedMarkers) - _selectedMarkers;
 } else {
-    GVAR(selectedMarkers) = _selectedMarkers;
+    if (_ctrlDown) then {
+        GVAR(selectedMarkers) = GVAR(selectedMarkers) + _selectedMarkers;
+    } else {
+        GVAR(selectedMarkers) = _selectedMarkers;
+    };
 };
 
 [] call FUNC(updateButtonSave);

--- a/addons/saveMarkers/functions/fn_onSavesListSelChanged.sqf
+++ b/addons/saveMarkers/functions/fn_onSavesListSelChanged.sqf
@@ -1,0 +1,29 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_ctrlSavesList","_selID"];
+
+if (_selID < 0) exitWith {
+    [] call FUNC(createMarkerPreview);
+    [IDC_BUTTONDELETE,false] call FUNC(setButtonEnabled);
+    [IDC_BUTTONLOAD,false] call FUNC(setButtonEnabled);
+};
+
+private _dataID = _ctrlSavesList lnbValue [_selID,0];
+private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
+(_saveMarkersData select _dataID) params ["_saveName","_worldName",["_markersData",[]]];
+
+if (_worldName != worldName) exitWith {
+    _ctrlSavesList lnbSetCurSelRow -1;
+};
+
+[IDC_BUTTONLOAD,true] call FUNC(setButtonEnabled);
+[IDC_BUTTONDELETE,true] call FUNC(setButtonEnabled);
+
+[_markersData] call FUNC(createMarkerPreview);
+
+private _display = ctrlParent _ctrlSavesList;
+private _ctrlEditName = _display displayCtrl IDC_EDITNAME;
+
+_ctrlEditName ctrlSetText _saveName;
+[] call FUNC(onEditNameChanged);

--- a/addons/saveMarkers/functions/fn_onSavesListSelChanged.sqf
+++ b/addons/saveMarkers/functions/fn_onSavesListSelChanged.sqf
@@ -13,14 +13,16 @@ private _dataID = _ctrlSavesList lnbValue [_selID,0];
 private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
 (_saveMarkersData select _dataID) params ["_saveName","_worldName",["_markersData",[]]];
 
-if (_worldName != worldName) exitWith {
-    _ctrlSavesList lnbSetCurSelRow -1;
-};
+private _isThisWorld = _worldName == worldName;
 
-[IDC_BUTTONLOAD,true] call FUNC(setButtonEnabled);
+[IDC_BUTTONLOAD,_isThisWorld] call FUNC(setButtonEnabled);
 [IDC_BUTTONDELETE,true] call FUNC(setButtonEnabled);
 
-[_markersData] call FUNC(createMarkerPreview);
+if (_isThisWorld) then {
+    [_markersData] call FUNC(createMarkerPreview);
+} else {
+    [] call FUNC(createMarkerPreview);
+};
 
 private _display = ctrlParent _ctrlSavesList;
 private _ctrlEditName = _display displayCtrl IDC_EDITNAME;

--- a/addons/saveMarkers/functions/fn_onUnload.sqf
+++ b/addons/saveMarkers/functions/fn_onUnload.sqf
@@ -1,0 +1,6 @@
+#include "script_component.hpp"
+
+[] call FUNC(createMarkerPreview);
+
+GVAR(selectedMarkers) = nil;
+GVAR(previewMarkers) = nil;

--- a/addons/saveMarkers/functions/fn_onUnload.sqf
+++ b/addons/saveMarkers/functions/fn_onUnload.sqf
@@ -4,3 +4,5 @@
 
 GVAR(selectedMarkers) = nil;
 GVAR(previewMarkers) = nil;
+
+onMapSingleClick "";

--- a/addons/saveMarkers/functions/fn_openDialog.sqf
+++ b/addons/saveMarkers/functions/fn_openDialog.sqf
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+
+private _canOpen = switch (true) do {
+    case (IS_ADMIN): {true};
+    case (GVAR(setting_canBeOpened) == 2): {true};
+    case (GVAR(setting_canBeOpened) == 1 && {(missionNamespace getVariable ["CBA_missionTime",0]) < 300}): {true};
+    default {false};
+};
+
+if (!_canOpen) exitWith {
+    playSound "3DEN_notificationWarning";
+    systemChat "GRAD saveMarkers is currently disabled by the mission. Log in as admin to use.";
+};
+
+[] call FUNC(loadDisplay);

--- a/addons/saveMarkers/functions/fn_openDialog.sqf
+++ b/addons/saveMarkers/functions/fn_openDialog.sqf
@@ -3,7 +3,7 @@
 private _canOpen = switch (true) do {
     case (IS_ADMIN): {true};
     case (GVAR(setting_canBeOpened) == 2): {true};
-    case (GVAR(setting_canBeOpened) == 1 && {(missionNamespace getVariable ["CBA_missionTime",0]) < 300}): {true};
+    case (GVAR(setting_canBeOpened) == 1 && {(missionNamespace getVariable ["CBA_missionTime",0]) < 600}): {true};
     default {false};
 };
 

--- a/addons/saveMarkers/functions/fn_saveMarkers.sqf
+++ b/addons/saveMarkers/functions/fn_saveMarkers.sqf
@@ -1,0 +1,44 @@
+#include "script_component.hpp"
+
+params ["_saveAs","_worldName","_markers"];
+
+private _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
+if (isNil "_saveMarkersData") then {
+    profileNamespace setVariable [QGVAR(saveData),[]];
+    _saveMarkersData = profileNamespace getVariable QGVAR(saveData);
+};
+
+private _existingSaveID = -1;
+{
+    _x params ["_thisSaveAs","_thisWorldName"];
+    if (_thisSaveAs == _saveAs && {_worldName == _thisWorldName}) exitWith {
+        _existingSaveID = _forEachIndex;
+    };
+} forEach _saveMarkersData;
+
+private _thisDataMarkersArray = if (_existingSaveID < 0) then {
+    (_saveMarkersData select (_saveMarkersData pushBack [_saveAs,_worldName,[]])) select 2
+} else {
+    (_saveMarkersData select _existingSaveID) select 2;
+};
+_thisDataMarkersArray resize 0;
+
+{
+    _thisDataMarkersArray pushBack [
+        markerAlpha _x,
+        markerBrush _x,
+        markerColor _x,
+        markerDir _x,
+        markerPos _x,
+        markerShape _x,
+        markerSize _x,
+        markerText _x,
+        markerType _x,
+        [_x] call FUNC(getMarkerChannel)
+    ];
+
+} forEach _markers;
+
+saveProfileNamespace;
+
+_newSaveID

--- a/addons/saveMarkers/functions/fn_setButtonEnabled.sqf
+++ b/addons/saveMarkers/functions/fn_setButtonEnabled.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_idc","_enabled"];
+
+private _display = findDisplay IDD_SAVEMARKERS;
+private _ctrlButton = _display displayCtrl _idc;
+
+_ctrlButton ctrlEnable _enabled;

--- a/addons/saveMarkers/functions/fn_setListSelected.sqf
+++ b/addons/saveMarkers/functions/fn_setListSelected.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_display",["_selID",-1]];
+
+if (isNil "_display") then {
+    _display = findDisplay IDD_SAVEMARKERS;
+};
+
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+if (isNil "_ctrlSavesList" || {isNull _ctrlSavesList}) exitWith {};
+
+_ctrlSavesList lnbSetCurSelRow _selID;

--- a/addons/saveMarkers/functions/fn_toggleHelp.sqf
+++ b/addons/saveMarkers/functions/fn_toggleHelp.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+GVAR(helpEnabled) = !(missionNamespace getVariable [QGVAR(helpEnabled),false]);
+
+private _display = findDisplay IDD_SAVEMARKERS;
+private _ctrlHelp = _display displayCtrl IDC_HELP;
+
+private _ctrlHelpPos = ctrlPosition _ctrlHelp;
+_ctrlHelpPos set [3,[1 * Y_FACTOR,22.2 * Y_FACTOR] select GVAR(helpEnabled)];
+_ctrlHelp ctrlSetPosition _ctrlHelpPos;
+_ctrlHelp ctrlCommit 0.5;

--- a/addons/saveMarkers/functions/fn_updateButtonSave.sqf
+++ b/addons/saveMarkers/functions/fn_updateButtonSave.sqf
@@ -1,0 +1,15 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_display"];
+
+if (isNil "_display") then {
+    _display = findDisplay IDD_SAVEMARKERS;
+};
+
+private _editText = ctrlText (_display displayCtrl IDC_EDITNAME);
+private _enabled = (count _editText > 0) && {count GVAR(selectedMarkers) > 0};
+
+diag_log ["updateButtonSave",_editText];
+
+[IDC_BUTTONSAVE,_enabled] call FUNC(setButtonEnabled);

--- a/addons/saveMarkers/functions/fn_updateButtonSave.sqf
+++ b/addons/saveMarkers/functions/fn_updateButtonSave.sqf
@@ -10,6 +10,4 @@ if (isNil "_display") then {
 private _editText = ctrlText (_display displayCtrl IDC_EDITNAME);
 private _enabled = (count _editText > 0) && {count GVAR(selectedMarkers) > 0};
 
-diag_log ["updateButtonSave",_editText];
-
 [IDC_BUTTONSAVE,_enabled] call FUNC(setButtonEnabled);

--- a/addons/saveMarkers/functions/fn_updateSavesList.sqf
+++ b/addons/saveMarkers/functions/fn_updateSavesList.sqf
@@ -16,7 +16,7 @@ private _saveMarkersData = profileNamespace getVariable [QGVAR(saveData),[]];
 {
     _x params [["_saveAs","ERROR: NO NAME"],["_worldName","ERROR: NO WORLDNAME"]];
 
-    _rowID = _ctrlSavesList lnbAddRow [_saveAs,_worldName];
+    private _rowID = _ctrlSavesList lnbAddRow [_saveAs,_worldName];
     _ctrlSavesList lnbSetValue [[_rowID,0],_forEachIndex];
 
     _textColor = [[0.50,0.50,0.50,1],[1,1,1,1]] select (_worldName == worldName);

--- a/addons/saveMarkers/functions/fn_updateSavesList.sqf
+++ b/addons/saveMarkers/functions/fn_updateSavesList.sqf
@@ -20,7 +20,6 @@ private _saveMarkersData = profileNamespace getVariable [QGVAR(saveData),[]];
     _ctrlSavesList lnbSetValue [[_rowID,0],_forEachIndex];
 
     _textColor = [[0.50,0.50,0.50,1],[1,1,1,1]] select (_worldName == worldName);
-    diag_log ["_textColor",_textColor];
     {_ctrlSavesList lnbSetColor [[_rowID,_x],_textColor]} forEach [0,1];
 } forEach _saveMarkersData;
 

--- a/addons/saveMarkers/functions/fn_updateSavesList.sqf
+++ b/addons/saveMarkers/functions/fn_updateSavesList.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+#include "..\ui\defines.hpp"
+
+params ["_display"];
+
+if (isNil "_display") then {
+    _display = findDisplay IDD_SAVEMARKERS;
+};
+
+private _ctrlSavesList = _display displayCtrl IDC_SAVESLIST;
+if (isNull _ctrlSavesList) exitWith {};
+
+lnbClear _ctrlSavesList;
+
+private _saveMarkersData = profileNamespace getVariable [QGVAR(saveData),[]];
+{
+    _x params [["_saveAs","ERROR: NO NAME"],["_worldName","ERROR: NO WORLDNAME"]];
+
+    _rowID = _ctrlSavesList lnbAddRow [_saveAs,_worldName];
+    _ctrlSavesList lnbSetValue [[_rowID,0],_forEachIndex];
+
+    _textColor = [[0.50,0.50,0.50,1],[1,1,1,1]] select (_worldName == worldName);
+    diag_log ["_textColor",_textColor];
+    {_ctrlSavesList lnbSetColor [[_rowID,_x],_textColor]} forEach [0,1];
+} forEach _saveMarkersData;
+
+_ctrlSavesList lnbSetCurSelRow _selID;

--- a/addons/saveMarkers/functions/script_component.hpp
+++ b/addons/saveMarkers/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/saveMarkers/script_component.hpp
+++ b/addons/saveMarkers/script_component.hpp
@@ -1,0 +1,4 @@
+#define COMPONENT saveMarkers
+
+#include "\x\grad\addons\main\script_mod.hpp"
+#include "\x\grad\addons\main\script_macros.hpp"

--- a/addons/saveMarkers/ui/defines.hpp
+++ b/addons/saveMarkers/ui/defines.hpp
@@ -5,6 +5,11 @@
 #define IDC_BUTTONSAVE              67400
 #define IDC_BUTTONLOAD              67500
 #define IDC_MAP                     67600
+#define IDC_HELP                    67991
+#define IDC_HELP_TEXT               67992
 
 #define X_FACTOR                    (((safezoneW / safezoneH) min 1.2) / 40)
 #define Y_FACTOR                    ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)
+
+#define HELP_TEXT_PADDING_X         (0.1 * X_FACTOR)
+#define HELP_TEXT_PADDING_Y         (0.1 * Y_FACTOR)

--- a/addons/saveMarkers/ui/defines.hpp
+++ b/addons/saveMarkers/ui/defines.hpp
@@ -1,0 +1,9 @@
+#define IDD_SAVEMARKERS             67000
+#define IDC_EDITNAME                67100
+#define IDC_SAVESLIST               67200
+#define IDC_BUTTONDELETE            67300
+#define IDC_BUTTONSAVE              67400
+#define IDC_BUTTONLOAD              67500
+
+#define X_FACTOR                    (((safezoneW / safezoneH) min 1.2) / 40)
+#define Y_FACTOR                    ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)

--- a/addons/saveMarkers/ui/defines.hpp
+++ b/addons/saveMarkers/ui/defines.hpp
@@ -4,6 +4,7 @@
 #define IDC_BUTTONDELETE            67300
 #define IDC_BUTTONSAVE              67400
 #define IDC_BUTTONLOAD              67500
+#define IDC_MAP                     67600
 
 #define X_FACTOR                    (((safezoneW / safezoneH) min 1.2) / 40)
 #define Y_FACTOR                    ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)

--- a/addons/saveMarkers/ui/dialog.hpp
+++ b/addons/saveMarkers/ui/dialog.hpp
@@ -12,14 +12,14 @@ class RscListNBox;
 class RscButtonMenu;
 
 
-class GVAR(displayMarkers) {
+class GVAR(RscDisplayMarkers) {
     access = 0;
     idd = IDD_SAVEMARKERS;
     movingEnable = 0;
 
     class controlsBackground {
         class map: RscMapControl {
-            idc = -1;
+            idc = IDC_MAP;
 
             x = "safezoneXAbs";
             y = "safezoneY";

--- a/addons/saveMarkers/ui/dialog.hpp
+++ b/addons/saveMarkers/ui/dialog.hpp
@@ -17,6 +17,8 @@ class GVAR(RscDisplayMarkers) {
     idd = IDD_SAVEMARKERS;
     movingEnable = 0;
 
+    onUnload = QUOTE(_this call FUNC(onUnload));
+
     class controlsBackground {
         class map: RscMapControl {
             idc = IDC_MAP;

--- a/addons/saveMarkers/ui/dialog.hpp
+++ b/addons/saveMarkers/ui/dialog.hpp
@@ -1,0 +1,161 @@
+#include "defines.hpp"
+#include "script_component.hpp"
+
+class RscMapControl;
+class RscPicture;
+class RscText;
+class RscTitle;
+class RscActiveText;
+class RscControlsGroupNoScrollbars;
+class RscEdit;
+class RscListNBox;
+class RscButtonMenu;
+
+
+class GVAR(displayMarkers) {
+    access = 0;
+    idd = IDD_SAVEMARKERS;
+    movingEnable = 0;
+
+    class controlsBackground {
+        class map: RscMapControl {
+            idc = -1;
+
+            x = "safezoneXAbs";
+            y = "safezoneY";
+            w = "safezoneWAbs";
+            h = "safezoneH";
+        };
+    };
+
+    class controls {
+
+        class markersDialog: RscControlsGroupNoScrollbars {
+            idc = -1;
+
+            x = safezoneX + safezoneW - 25 * X_FACTOR;
+            y = 0.9 * Y_FACTOR + (safezoneY + (safezoneH - (((safezoneW / safezoneH) min 1.2) / 1.2))/2);
+            w = 20 * X_FACTOR;
+            h = 22.2 * Y_FACTOR;
+
+            deletable = 0;
+            fade = 0;
+            shadow = 0;
+            style = 16;
+            type = 15;
+            moving = true;
+
+            class controls {
+                class title: RscTitle {
+                    idc = -1;
+
+                    x = 0 * X_FACTOR;
+                    y = 0 * Y_FACTOR;
+                    w = 20 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+
+                    sizeEx = (Y_FACTOR * 1);
+                    text = "GRAD SAVE-MARKERS";
+                    colorBackground[] = {"(profilenamespace getvariable ['GUI_BCG_RGB_R',0.13])","(profilenamespace getvariable ['GUI_BCG_RGB_G',0.54])","(profilenamespace getvariable ['GUI_BCG_RGB_B',0.21])","(profilenamespace getvariable ['GUI_BCG_RGB_A',0.8])"};
+                };
+
+                class mainBackground: RscText {
+                    idc = -1;
+
+                    x = 0 * X_FACTOR;
+                    y = 1.1 * Y_FACTOR;
+                    w = 20 * X_FACTOR;
+                    h = 20 * Y_FACTOR;
+
+                    SizeEx = (Y_FACTOR * 1);
+                    colorBackground[] = {0,0,0,0.8};
+                };
+
+                class editName: RscEdit {
+                    idc = IDC_EDITNAME;
+
+                    x = 6 * X_FACTOR;
+                    y = 19.6 * Y_FACTOR;
+                    w = 13.5 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+
+                    sizeEx = 0.8 * Y_FACTOR;
+                };
+
+                class saveAsText: RscText {
+                    idc = -1;
+
+                    text = "Save as:";
+
+                    x = 0.5 * X_FACTOR;
+                    y = 19.6 * Y_FACTOR;
+                    w = 5.5 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+
+                    sizeEx = 0.8 * Y_FACTOR;
+                    style = 1;
+                };
+
+                class savesList: RscListNBox {
+                    idc = IDC_SAVESLIST;
+
+                    x = 0.5 * X_FACTOR;
+                    y = 1.6 * Y_FACTOR;
+                    w = 19 * X_FACTOR;
+                    h = 17.5 * Y_FACTOR;
+
+                    sizeEx = 0.8 * Y_FACTOR;
+                    columns[] = {0,0.7};
+
+                    class ListScrollBar;
+                    class ScrollBar;
+                };
+
+                class buttonCancel: RscButtonMenu {
+                    idc = -1;
+                    text = "Cancel";
+
+                    action = QUOTE((findDisplay IDD_SAVEMARKERS) closeDisplay 2);
+
+                    x = 0 * X_FACTOR;
+                    y = 21.2 * Y_FACTOR;
+                    w = 4.925 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+                };
+
+                class buttonDelete: RscButtonMenu {
+                    idc = IDC_BUTTONDELETE;
+
+                    text = "Delete";
+
+                    x = 5.025 * X_FACTOR;
+                    y = 21.2 * Y_FACTOR;
+                    w = 4.925 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+                };
+
+                class buttonSave: RscButtonMenu {
+                    idc = IDC_BUTTONSAVE;
+
+                    text = "Save";
+
+                    x = 10.050 * X_FACTOR;
+                    y = 21.2 * Y_FACTOR;
+                    w = 4.925 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+                };
+
+                class buttonLoad: RscButtonMenu {
+                    idc = IDC_BUTTONLOAD;
+
+                    text = "Load";
+
+                    x = 15.075 * X_FACTOR;
+                    y = 21.2 * Y_FACTOR;
+                    w = 4.925 * X_FACTOR;
+                    h = 1 * Y_FACTOR;
+                };
+            };
+        };
+    };
+};

--- a/addons/saveMarkers/ui/dialog.hpp
+++ b/addons/saveMarkers/ui/dialog.hpp
@@ -10,6 +10,7 @@ class RscControlsGroupNoScrollbars;
 class RscEdit;
 class RscListNBox;
 class RscButtonMenu;
+class RscStructuredText;
 
 
 class GVAR(RscDisplayMarkers) {
@@ -32,11 +33,54 @@ class GVAR(RscDisplayMarkers) {
 
     class controls {
 
+        class helpDialog: RscControlsGroupNoScrollbars {
+            idc = IDC_HELP;
+
+            x = safezoneX + safezoneW - 13 * X_FACTOR;
+            y = safezoneY + 5 * Y_FACTOR;
+            w = 8 * X_FACTOR;
+            h = 22.2 * Y_FACTOR;
+
+            deletable = 0;
+            fade = 0;
+            shadow = 0;
+            style = 16;
+            type = 15;
+            moving = true;
+
+            class controls {
+                class mainBackground: RscText {
+                    idc = -1;
+
+                    x = 0;
+                    y = 0;
+                    w = 8 * X_FACTOR;
+                    h = 22.2 * Y_FACTOR;
+
+                    SizeEx = (Y_FACTOR * 1);
+                    colorBackground[] = {0,0,0,0.8};
+                };
+
+                class text: RscStructuredText {
+                    idc = IDC_HELP_TEXT;
+
+                    x = HELP_TEXT_PADDING_X;
+                    y = HELP_TEXT_PADDING_Y;
+                    w = 8 * X_FACTOR - 2 * HELP_TEXT_PADDING_X;
+                    h = 22.2 * Y_FACTOR - 2 * HELP_TEXT_PADDING_Y;
+
+                    sizeEx = 0.8 * Y_FACTOR;
+
+                    class Attributes;
+                };
+            };
+        };
+
         class markersDialog: RscControlsGroupNoScrollbars {
             idc = -1;
 
-            x = safezoneX + safezoneW - 25 * X_FACTOR;
-            y = 0.9 * Y_FACTOR + (safezoneY + (safezoneH - (((safezoneW / safezoneH) min 1.2) / 1.2))/2);
+            x = safezoneX + 5 * X_FACTOR;
+            y = safezoneY + 5 * Y_FACTOR;
             w = 20 * X_FACTOR;
             h = 22.2 * Y_FACTOR;
 

--- a/addons/saveMarkers/ui/script_component.hpp
+++ b/addons/saveMarkers/ui/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"


### PR DESCRIPTION
- dialog based interaction
- select markers, save selected
- select saved set from list, preview, load
- open with chatcommand or from help
- CBA setting for enabling opening of dialog [never, first 5 minutes of mission, always]

ToDo:
- [x] notification for players that have saved sets for the current map when markers can be loaded