### PR TITLE
Fixed onLrChannelSet error

### DIFF
--- a/addons/zeus/XEH_preClientInit.sqf
+++ b/addons/zeus/XEH_preClientInit.sqf
@@ -53,7 +53,7 @@ Drop this anywhere. Toggles Blue Force Tracking.<br/>";
 [
     "TFAR_event_OnLRchannelSet",
     {
-        params ["_unit", "", "_channel", "_additional"];
+        params ["_unit", "", "", "_channel", "_additional"];
 
         private _frequency = [(call TFAR_fnc_activeLRRadio), (_channel +1)] call TFAR_fnc_getChannelFrequency;
         if (_additional) then {


### PR DESCRIPTION
Fixes:
```
21:22:11 Error in expression <call TFAR_fnc_activeLRRadio), (_channel +1)] call TFAR_fnc_getChannelFrequency;
>
21:22:11   Error position: <+1)] call TFAR_fnc_getChannelFrequency;
>
21:22:11   Error Generic error in expression
21:22:11 File x\GRAD\addons\zeus\XEH_preClientInit.sqf, line 58
```
Caused by wrong size of `params`, see: https://github.com/michail-nikolaev/task-force-arma-3-radio/blob/3b78acf9be468f54bc3179b9f7de87dd7941c375/addons/core/functions/fnc_setAdditionalLrChannel.sqf#L33