### PR TITLE
safe boating

### DIFF
--- a/addons/main/script_mod.hpp
+++ b/addons/main/script_mod.hpp
@@ -1,9 +1,9 @@
 #define PREFIX GRAD
 #define MAINPREFIX x
 
-#define MINOR 14
+#define MINOR 15
 #define PATCHLVL 0
-#define COMMIT 0d37ee5
+#define COMMIT 7838c21
 
 #define VERSION MAJOR.MINOR.PATCHLVL
 #define VERSION_AR MAJOR,MINOR,PATCHLVL

--- a/addons/safeBoating/$PBOPREFIX$
+++ b/addons/safeBoating/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\grad\addons\safeBoating

--- a/addons/safeBoating/CfgEventHandlers.hpp
+++ b/addons/safeBoating/CfgEventHandlers.hpp
@@ -1,0 +1,24 @@
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_InitPost_EventHandlers  {
+    class Rubber_duck_base_F {
+        class ADDON {
+            init = QUOTE(_this call FUNC(addHandleDamageBoat));
+        };
+    };
+    class Boat_Transport_02_base_F {
+        class ADDON {
+            init = QUOTE(_this call FUNC(addHandleDamageBoat));
+        };
+    };
+};

--- a/addons/safeBoating/README.md
+++ b/addons/safeBoating/README.md
@@ -1,0 +1,12 @@
+### safeBoating
+
+Prevents excessive damage when bumping your boat into thingies.
+
+#### Maintainer(s)
+
+* Fusselwurm
+
+#### Description
+
+In Arma3, You can insta-die when you gently float your rubber boat against a mangrove sapling.
+This module aims to prevent that kind of shit.

--- a/addons/safeBoating/XEH_PREP.hpp
+++ b/addons/safeBoating/XEH_PREP.hpp
@@ -1,0 +1,4 @@
+PREP(addHandleDamageBoat);
+PREP(handleDamageBoat);
+
+PREP(spec);

--- a/addons/safeBoating/XEH_preInit.sqf
+++ b/addons/safeBoating/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/safeBoating/XEH_preStart.sqf
+++ b/addons/safeBoating/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/safeBoating/config.cpp
+++ b/addons/safeBoating/config.cpp
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		author = "$STR_grad_Author";
+		name = QUOTE(ADDON);
+		url = "$STR_grad_URL";
+		requiredAddons[] = {
+			"grad_main"
+		};
+		units[] = {};
+		weapons[] = {};
+		VERSION_CONFIG;
+		authors[] = {"Fusselwurm"};
+	};
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/safeBoating/functions/fnc_addHandleDamageBoat.sqf
+++ b/addons/safeBoating/functions/fnc_addHandleDamageBoat.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+_this#0 addEventHandler ['HandleDamage', FUNC(handleDamageBoat)]

--- a/addons/safeBoating/functions/fnc_handleDamageBoat.sqf
+++ b/addons/safeBoating/functions/fnc_handleDamageBoat.sqf
@@ -1,0 +1,25 @@
+#include "script_component.hpp"
+
+params ["_unit", "_selection", "_damage", "_source", "_projectile", "_hitIndex", "_instigator", "_hitPoint"];
+
+private _boat = vehicle _unit; // yes, this will even work if _unit is the unmanned boat itself
+
+// NOTE: getHit / getHitIndex will oftentimes falsely return 0 ,
+//       hence we need to remember the previos damage.
+private _damageVar = format ["grad_safeBoating_damage_%1", _selection];
+
+if (!(isNull _source && (_projectile == "") && isNull _instigator)) exitWith {
+    _boat setVariable [_damageVar, _damage, true];
+    nil
+};
+
+private _absSpeed = abs speed _boat;
+private _maxAllowedDamage = _absSpeed / 50;
+
+
+private _previousDamage = _boat getVariable [_damageVar, 0];
+LOG_4("%1 previous damage %2, new damage value %3; speed damage could be %4", _boat, _previousDamage, _damage, _maxAllowedDamage);
+private _finalDamage = (_maxAllowedDamage min _damage) max _previousDamage;
+LOG_3("set damage %1 to boat part '%2' from bumping into things at speed %3", _finalDamage, _selection, _absSpeed);
+_boat setVariable [_damageVar, _finalDamage, true];
+_finalDamage

--- a/addons/safeBoating/functions/fnc_spec.sqf
+++ b/addons/safeBoating/functions/fnc_spec.sqf
@@ -1,0 +1,172 @@
+#include "script_component.hpp"
+
+["a rubber boat",
+    {
+        if (worldName != "VR") then {
+            throw "needs to run in VR!";
+        };
+        private _boat = "O_Boat_Transport_01_F" createVehicle [0, 0, 0];
+        _boat setPos [7501, 7535, 0.1];
+        _boat setDir 135;
+        createVehicleCrew _boat;
+        private _tree = createSimpleObject ["Land_HBarrier_5_F", [7506, 7529, 0]];
+
+        _tree setDir 128;
+
+        [_boat, _tree, crew _boat]
+    },
+    [
+        ["I crash at extremely high speed > 50km/h",
+            {
+                params [["_boat", objNull]];
+                private _driver = driver _boat;
+                _boat setVelocityModelSpace  [0, 20, 0];
+                sleep 1.5;
+                [_boat, _driver]
+            },
+            [
+                ["does get destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [alive _boat, false] call grad_testing_fnc_assertEquals;
+                    }
+                ]
+            ]
+        ],
+        ["I crash at high speed ~ 25km/h",
+            {
+                params [["_boat", objNull]];
+                _boat setVelocityModelSpace  [0, 8, 0];
+                sleep 1.5;
+                [_boat]
+            },
+            [
+                ["does get damaged somewhat without being destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [damage _boat, 0.2] call grad_testing_fnc_assertGreaterThan;
+                        [alive _boat, true] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["does not hurt the occupant",
+                    {
+                        params [["_boat", objNull]];
+                        [0, damage (driver _boat)] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["and bump again very slightly afterward",
+                    {
+                        params [["_boat", objNull]];
+                        private _damage = damage _boat;
+                        _boat setPos [7496, 7540, 0.1];
+                        _boat setVelocityModelSpace [0, 3, 0];
+                        sleep 3;
+                        [_boat, _damage]
+                    },
+                    [
+                        ["retains the higher damage from the first bump",
+                            {
+                                params [["_boat", objNull], ["_firstDamage", -1]];
+                                [_firstDamage, 0.4] call grad_testing_fnc_assertGreaterThan;
+                                [damage _boat, _firstDamage] call grad_testing_fnc_assertEquals;
+                            }
+                        ]
+                    ]
+                ]
+            ]
+        ],
+        ["I bump at low speed",
+            {
+                params [["_boat", objNull]];
+                _boat setVelocityModelSpace  [0, 3, 0];
+                sleep 3;
+                [_boat]
+            },
+            [
+                ["does not get damaged",
+                    {
+                        params [["_boat", objNull]];
+                        [0, damage _boat] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["does not hurt the occupant",
+                    {
+                        params [["_boat", objNull]];
+                        [0, damage (driver _boat)] call grad_testing_fnc_assertEquals;
+                    }
+                ]
+            ]
+        ],
+        ["that gets hit by an explosion",
+            {
+                params [["_boat", objNull]];
+                private _driver = driver _boat;
+                _bomb = "APERSTripMine_Wire_Ammo" createVehicle (getPos _boat);
+                _bomb setdamage 1;
+                sleep 1;
+                [_boat, _driver]
+            },
+            [
+                ["gets destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [alive _boat, false] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["kills the occupant",
+                    {
+                        // NOTE: for some reason, boat occupants are protected from explosions. to be investigated.
+                        // so even when they should be killed - retuned damage is 1 - they actually are not.
+                        //params [["_boat", objNull], ["_driver", objNull]];
+                        // [alive _driver, false] call grad_testing_fnc_assertEquals;
+                        ["does not work. #not_our_fault"] call grad_testing_fnc_skipTest;
+                    }
+                ]
+            ]
+        ],
+        ["that gets hit by a few bullets",
+            {
+                params [["_boat", objNull]];
+                private _projectilePos = (getPosASL _boat) vectorAdd [0, -6, 0.3];
+                for "_i" from 0 to 8 do {
+                    private _projectile = "B_65x39_Case_yellow" createVehicle _projectilePos;
+                    _projectile setPosASL _projectilePos;
+                    _projectile setVelocity [0, 800, 0];
+                };
+                sleep 1;
+                [_boat]
+            },
+            [
+                ["nearly gets destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [damage _boat, 0.7, 0.9] call grad_testing_fnc_assertBetween;
+                    }
+                ],
+                ["and later bumps with moderate speed",
+                    {
+                        params [["_boat", objNull]];
+                        _boat setVelocityModelSpace  [0, 8, 0];
+                        sleep 1.5;
+                        [_boat]
+                    },
+                    [
+                        ["keeps the high bullet damage",
+                            {
+                                params [["_boat", objNull]];
+                                [damage _boat, 0.7, 0.9] call grad_testing_fnc_assertBetween;
+                            }
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ],
+    {
+        params [["_boat", objNull], ["_tree", objNull], ["_crew", []]];
+        { deleteVehicle _x } forEach _crew;
+        deleteVehicle _boat;
+        deleteVehicle _tree;
+        sleep 0.2;
+    }
+] call grad_testing_fnc_executeTest;

--- a/addons/safeBoating/functions/script_component.hpp
+++ b/addons/safeBoating/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/safeBoating/script_component.hpp
+++ b/addons/safeBoating/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT safeBoating
+
+#define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\x\grad\addons\main\script_mod.hpp"
+#include "\x\grad\addons\main\script_macros.hpp"

--- a/addons/testing/$PBOPREFIX$
+++ b/addons/testing/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\grad\addons\testing

--- a/addons/testing/CfgEventHandlers.hpp
+++ b/addons/testing/CfgEventHandlers.hpp
@@ -1,0 +1,11 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/addons/testing/README.md
+++ b/addons/testing/README.md
@@ -1,0 +1,142 @@
+### testing
+
+Unit testing framework
+
+#### Maintainer(s)
+
+* Fusselwurm
+
+#### Description
+
+**Automate script testing.**
+
+*If you're familiar with behavior-driven testing frameworks like Javascript's Jasmine, this one will feel familiar.*
+
+Testing falls roughly into these stages:
+* setup: place entities, set global variables etc
+* test execution: trigger the thing you want to test                                 
+* assertion: see that the thing happened you wanted to happen
+* cleanup: remove everything and reset variables
+
+Often, your setup varies slightly across different tests as your code branches out, and you want to test every branch.
+
+To reflect this, with this framework you declare a tree of setups, with the actual test execution as the leave nodes.
+
+Every branch consists of these elements:
+* a description
+* a setup code block
+* an array of children
+* a cleanup code block
+
+Leaf nodes are marked by having neither children nor cleanup, and in place of the setup code block you put a block with assertions.
+
+Every setup block receives the parent setup's return value as parameter.
+
+Every cleanup block receives its own node's setup return value as parameter.
+
+When running the tests, **every leaf is executed in isolation** - preceded by all its ancestors setups, and succeeded by all its ancestors cleanups.
+
+In the end, the results are pretty-printed to systemChat as well as `rpt`.
+
+#### Usage example
+
+```arma.sqf
+
+["a rubber boat",
+    {
+        if (worldName != "VR") then {
+            throw "needs to run in VR!";
+        };
+        private _boat = "O_Boat_Transport_01_F" createVehicle [0, 0, 0];
+        _boat setPos [7501, 7535, 0.1];
+        _boat setDir 135;
+        createVehicleCrew _boat;
+        private _tree = createSimpleObject ["Land_HBarrier_5_F", [7506, 7529, 0]];
+
+        _tree setDir 128;
+
+        [_boat, _tree, crew _boat]
+    },
+    [
+        ["I crash at extremely high speed > 50km/h",
+            {
+                params [["_boat", objNull]];
+                private _driver = driver _boat;
+                _boat setVelocityModelSpace  [0, 20, 0];
+                sleep 1.5;
+                [_boat, _driver]
+            },
+            [
+                ["does get destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [alive _boat, false] call grad_testing_fnc_assertEquals;
+                    }
+                ]
+            ]
+        ],
+        ["I crash at high speed ~ 25km/h",
+            {
+                params [["_boat", objNull]];
+                _boat setVelocityModelSpace  [0, 8, 0];
+                sleep 1.5;
+                [_boat]
+            },
+            [
+                ["does get damaged somewhat without being destroyed",
+                    {
+                        params [["_boat", objNull]];
+                        [damage _boat, 0.2] call grad_testing_fnc_assertGreaterThan;
+                        [alive _boat, true] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["does not hurt the occupant",
+                    {
+                        params [["_boat", objNull]];
+                        [0, damage (driver _boat)] call grad_testing_fnc_assertEquals;
+                    }
+                ],
+                ["and bump again very slightly afterward",
+                    {
+                        params [["_boat", objNull]];
+                        private _damage = damage _boat;
+                        _boat setPos [7496, 7540, 0.1];
+                        _boat setVelocityModelSpace [0, 3, 0];
+                        sleep 3;
+                        [_boat, _damage]
+                    },
+                    [
+                        ["retains the higher damage from the first bump",
+                            {
+                                params [["_boat", objNull], ["_firstDamage", -1]];
+                                [_firstDamage, 0.4] call grad_testing_fnc_assertGreaterThan;
+                                [damage _boat, _firstDamage] call grad_testing_fnc_assertEquals;
+                            }
+                        ]
+                    ]
+                ]
+            ]
+        ]
+    ],
+    {
+        params [["_boat", objNull], ["_tree", objNull], ["_crew", []]];
+        { deleteVehicle _x } forEach _crew;
+        deleteVehicle _boat;
+        deleteVehicle _tree;
+        sleep 0.2;
+    }
+] call grad_testing_fnc_executeTest;
+
+```
+
+may output:
+
+```
+20:32:06 "OK       a rubber boat I crash at extremely high speed > 50km/h does get destroyed"
+20:32:06 "OK       a rubber boat I crash at high speed ~ 25km/h does get damaged somewhat"
+20:32:06 "OK       a rubber boat I crash at high speed ~ 25km/h is not destroyed"
+20:32:06 "OK       a rubber boat I crash at high speed ~ 25km/h does not hurt the occupant"
+20:32:06 "OK       a rubber boat I crash at high speed ~ 25km/h and bump again very slightly afterward retains the higher damage from the first bump"
+```
+
+which looks a bit like this: https://youtu.be/LLb9savQ4c8

--- a/addons/testing/XEH_PREP.hpp
+++ b/addons/testing/XEH_PREP.hpp
@@ -1,0 +1,9 @@
+PREP(addAssertionResult);
+PREP(assertBetween);
+PREP(assertEquals);
+PREP(assertGreaterThan);
+PREP(assertLessThan);
+PREP(executeContext);
+PREP(executeTest);
+PREP(printResults);
+PREP(skipTest);

--- a/addons/testing/XEH_preInit.sqf
+++ b/addons/testing/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/testing/XEH_preStart.sqf
+++ b/addons/testing/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/testing/config.cpp
+++ b/addons/testing/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		author = "$STR_grad_Author";
+		name = QUOTE(ADDON);
+		url = "$STR_grad_URL";
+		requiredAddons[] = {};
+		units[] = {};
+		weapons[] = {};
+		VERSION_CONFIG;
+		authors[] = {"Fusselwurm"};
+	};
+};
+
+#include "CfgEventHandlers.hpp"

--- a/addons/testing/functions/fnc_addAssertionResult.sqf
+++ b/addons/testing/functions/fnc_addAssertionResult.sqf
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+params [
+    ["_status", STATUS_FAIL],
+    ["_message", ""]
+];
+
+if (count grad_testing_results == 0) then {
+    throw "cannot run test assertions, we are not in a test context!";
+};
+
+private _leaf = grad_testing_results select (count grad_testing_results - 1);
+private _descriptions = _leaf#0;
+private _results = _leaf#1;
+_results pushBack [_status, _message];
+
+private _line = format ["%1  %2",
+    _status,
+    (_descriptions joinString " ")
+];
+
+INFO(_line);

--- a/addons/testing/functions/fnc_assertBetween.sqf
+++ b/addons/testing/functions/fnc_assertBetween.sqf
@@ -1,0 +1,28 @@
+#include "script_component.hpp"
+
+params [
+    ["_actual", scriptNull],
+    ["_lower", scriptNull],
+    ["_upper", scriptNull],
+    ["_message", ""]
+];
+
+if (_message == "") then {
+    _message = format ["%1 < %2 < %3", _lower, _actual, _upper];
+};
+
+if (typeName _actual != "SCALAR") exitWith {
+    [STATUS_ERROR, "first parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+if (typeName _lower != "SCALAR") exitWith {
+    [STATUS_ERROR, "second parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+if (typeName _upper != "SCALAR") exitWith {
+    [STATUS_ERROR, "third parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+
+if (_actual > _lower && _actual < _upper) then {
+    [STATUS_SUCCESS, _message] call grad_testing_fnc_addAssertionResult;
+} else {
+    [STATUS_FAIL, _message] call grad_testing_fnc_addAssertionResult;
+}

--- a/addons/testing/functions/fnc_assertEquals.sqf
+++ b/addons/testing/functions/fnc_assertEquals.sqf
@@ -1,0 +1,13 @@
+#include "script_component.hpp"
+
+params [
+    ["_a", scriptNull],
+    ["_b", scriptNull],
+    ["_message", ""]
+];
+
+if (_a isEqualTo _b) then {
+    [STATUS_SUCCESS, _message] call grad_testing_fnc_addAssertionResult;
+} else {
+    [STATUS_FAIL, _message] call grad_testing_fnc_addAssertionResult;
+}

--- a/addons/testing/functions/fnc_assertGreaterThan.sqf
+++ b/addons/testing/functions/fnc_assertGreaterThan.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+
+params [
+    ["_a", scriptNull],
+    ["_b", scriptNull],
+    ["_message", ""]
+];
+
+if (typeName _a != "SCALAR") exitWith {
+    [STATUS_ERROR, "first parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+if (typeName _b != "SCALAR") exitWith {
+    [STATUS_ERROR, "second parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+
+if (_a > _b) then {
+    [STATUS_SUCCESS, _message] call grad_testing_fnc_addAssertionResult;
+} else {
+    [STATUS_FAIL, _message] call grad_testing_fnc_addAssertionResult;
+}

--- a/addons/testing/functions/fnc_assertLessThan.sqf
+++ b/addons/testing/functions/fnc_assertLessThan.sqf
@@ -1,0 +1,20 @@
+#include "script_component.hpp"
+
+params [
+    ["_a", scriptNull],
+    ["_b", scriptNull],
+    ["_message", ""]
+];
+
+if (typeName _a != "SCALAR") exitWith {
+    [STATUS_ERROR, "first parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+if (typeName _b != "SCALAR") exitWith {
+    [STATUS_ERROR, "second parameter is not a number"] call grad_testing_fnc_addAssertionResult;
+};
+
+if (_a < _b) then {
+    [STATUS_SUCCESS, _message] call grad_testing_fnc_addAssertionResult;
+} else {
+    [STATUS_FAIL, _message] call grad_testing_fnc_addAssertionResult;
+}

--- a/addons/testing/functions/fnc_executeContext.sqf
+++ b/addons/testing/functions/fnc_executeContext.sqf
@@ -1,0 +1,54 @@
+#include "script_component.hpp";
+
+params [
+    ["_context", []],
+    ["_my", []]
+];
+
+_context params [
+    ["_descriptions", []],
+    ["_setups", []],
+    ["_cleanups", []]
+];
+
+_my params [
+    ["_description", ""],
+    ["_setup", {[]}],
+    ["_subroutines", []],
+    ["_cleanup", {[]}]
+];
+
+_setups = _setups + [_setup];
+_cleanups = _cleanups + [_cleanup];
+_descriptions = _descriptions + [_description];
+
+if (count _subroutines > 0) then {
+    {
+        [
+            [
+                _descriptions,
+                _setups,
+                _cleanups
+            ],
+           _x
+        ] call grad_testing_fnc_executeContext;
+    } forEach _subroutines;
+} else {
+    grad_testing_results pushBack [_descriptions, [/*assertion results will go here*/]];
+
+    private _setupParameter = [];
+    private _cleanupParameters = [];
+    {
+        _setupParameter = _setupParameter call _x;
+        ISNILS(_setupParameter, []);
+        LOG(str _x);
+        _cleanupParameters pushBack _setupParameter;
+    } forEach _setups;
+    {
+        // call cleanups with the respective setup's return value.
+        private _cleanupParameter = _cleanupParameters#_forEachIndex;
+        ISNILS(_cleanupParameter, []);
+        LOG(str _x);
+        _cleanupParameter call _x;
+    } forEach _cleanups;
+};

--- a/addons/testing/functions/fnc_executeTest.sqf
+++ b/addons/testing/functions/fnc_executeTest.sqf
@@ -1,0 +1,6 @@
+_this spawn {
+    grad_testing_results = [];
+    [[], _this] call grad_testing_fnc_executeContext;
+
+    [grad_testing_results] call grad_testing_fnc_printResults;
+};

--- a/addons/testing/functions/fnc_printResults.sqf
+++ b/addons/testing/functions/fnc_printResults.sqf
@@ -1,0 +1,36 @@
+#include "script_component.hpp"
+
+{
+    _x params ["_path", "_results"];
+
+    private _overallResultOkay = {
+        _assertionResult = _x select 0;
+        if (!(_assertionResult isEqualTo STATUS_SUCCESS)) exitWith {
+            false
+        };
+        true
+    } forEach _results;
+
+    if (_overallResultOkay) then {
+        private _text = format["OK       %1", (_path joinString " ")];
+        systemChat _text;
+        diag_log _text;
+    } else {
+        private _text = format["!!       %1", (_path joinString " ")];
+        systemChat _text;
+        diag_log _text;
+        {
+            private _textStatus = switch (_x select 0) do {
+                case STATUS_FAIL:    {"FAIL   "};
+                case STATUS_ERROR:   {"ERROR  "};
+                case STATUS_SUCCESS: {"OK     "};
+                case STATUS_PENDING: {"PENDING"};
+                default              {"???    "};
+            };
+            private _message = _x select 1;
+            _text = format ["    %1  %2", _textStatus, _message];
+            systemChat _text;
+            diag_log _text;
+        } forEach _results;
+    };
+} forEach grad_testing_results;

--- a/addons/testing/functions/fnc_skipTest.sqf
+++ b/addons/testing/functions/fnc_skipTest.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+params [
+    ["_message", ""]
+];
+
+[STATUS_SKIPPED, _message] call grad_testing_fnc_addAssertionResult;

--- a/addons/testing/functions/script_component.hpp
+++ b/addons/testing/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/testing/script_component.hpp
+++ b/addons/testing/script_component.hpp
@@ -1,0 +1,14 @@
+#define COMPONENT testing
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\x\grad\addons\main\script_mod.hpp"
+#include "\x\grad\addons\main\script_macros.hpp"
+
+#define STATUS_ERROR "error"
+#define STATUS_FAIL "fail"
+#define STATUS_PENDING "pending"
+#define STATUS_SKIPPED "skipped"
+#define STATUS_SUCCESS "success"


### PR DESCRIPTION
will fix #141 

**prevent destruction due to collisions as long as boat stays under 50km/h**
corollaries:
* boats can now push other boats without any one of them getting destroyed
* you can drive over mangrove saplings and clutter without dying

note: **players still will get a few scratches** due to ACE medical

----

NEW MODULE "safeBoating"
* reduce collision damage for rubber boats and RHIBs
  so that crashes at <50km/h do not lead to destruction
* plus unit test (*fnc_test)

implementation notes:
* add damage handler in postInit, because
	* handleDamage is not supported by XEH
	* trying to do QUOTE(_this#0 addEventHandler [ … something will
	  result in empty string within the quote
* player does not need damage handler, players dying in boat
  collisions was *probably* only due to the boat being destroyed &
  the player being ejected at speed.

NEW MODULE "testing"
* BDD-style unit test library
* see README for usage example

----

**TODO**
- [x] ~~catch ace medical damage~~ wont kill you, it's fine to get a few bruises.
- [x] limit damage prevention based on speed
- [x] test against RHSPKL vegetation
- [x] include RHIBs
- [x] test RHIBs