### PR TITLE
call activelrradio in non-scheduled environment

### DIFF
--- a/addons/zeus/XEH_preClientInit.sqf
+++ b/addons/zeus/XEH_preClientInit.sqf
@@ -64,7 +64,8 @@ if  (isClass (configFile >> "CfgPatches" >> "tfar_core")) then {
 
             params ["_unit", "", "", "_channel", "_additional"];
 
-            private _frequency = [(call TFAR_fnc_activeLRRadio), (_channel +1)] call TFAR_fnc_getChannelFrequency;
+            // TFAR_fnc_activeLRRadio has to be called in a non-scheduled environment
+            private _frequency = {[(call TFAR_fnc_activeLRRadio), (_channel + 1)] call TFAR_fnc_getChannelFrequency; } call CBA_fnc_directCall;
             if (_additional) then {
 
                 if (_channel isEqualTo (_unit getVariable [QGVAR(freqAdditionalLR), -1])) exitWith {


### PR DESCRIPTION
Fixes:
```
17:33:03 Error in expression <e _result = [];

_result pushBackUnique _overrideLR; 
if (_activeLR isEqualTo _v>
17:33:03   Error position: <_overrideLR; 
if (_activeLR isEqualTo _v>
17:33:03   Error Undefined variable in expression: _overridelr
17:33:03 File z\tfar\addons\core\functions\fnc_lrRadiosList.sqf..., line 35
```

`lrRadiosList`/`activeLRRadio` has to be called in a non-scheduled environment. More info: https://github.com/michail-nikolaev/task-force-arma-3-radio/issues/1306