### PR TITLE
various fixes for animalTransport

### DIFF
--- a/addons/animalTransport/CfgVehicles.hpp
+++ b/addons/animalTransport/CfgVehicles.hpp
@@ -4,7 +4,26 @@ class CfgVehicles {
         class GRAD_AnimalTransport {
             stop = "Sheep_Stop";
             default = "Sheep_Idle_Stop";
-            actionPoint[] = {0, 0.35, 0.65};
+        };
+        class ACE_Actions {
+            class ACE_MainActions {
+                displayName = CSTRING(MainAction);
+                distance = 3;
+                condition = QUOTE(true);
+                statement = "";
+                icon = "\a3\ui_f\data\IGUI\Cfg\Actions\eject_ca.paa";
+                position = "[0, 0.35, 0.65]";
+
+                class GVAR(loadAction) {
+                    displayName = "load on vehicle";
+                    distance = 3;
+                    condition = QUOTE([_target] call FUNC(interact_loadCondition));
+                    statement = QUOTE([_target] call FUNC(interact_loadAction));
+                    insertChildren = QUOTE([_target] call FUNC(interact_loadChildren));
+                    icon = "\a3\ui_f\data\IGUI\Cfg\Actions\loadVehicle_ca.paa";
+                };
+
+            };
         };
         ACE_dragging_canCarry = 1;
         ACE_dragging_carryPosition[] = {-0.5, 0.6, 0.5};

--- a/addons/animalTransport/XEH_PREP.hpp
+++ b/addons/animalTransport/XEH_PREP.hpp
@@ -3,6 +3,7 @@ PREP(findSuitableSpace);
 PREP(findSuitableSpaces);
 PREP(findSuitableVehicle);
 PREP(findSuitableVehicles);
+PREP(findTransportsInLoadingRange);
 PREP(getSupportedAnimalConfigs);
 PREP(getCustomConfig);
 PREP(getSupportedCarConfigs);

--- a/addons/animalTransport/XEH_postClientInit.sqf
+++ b/addons/animalTransport/XEH_postClientInit.sqf
@@ -5,48 +5,6 @@ LOG("postClientInit");
 if (!hasInterface) exitWith {};
 
 {
-    private _interactPoint = ([_x >> "GRAD_AnimalTransport", "actionPoint", [0, 0, 0]] call BIS_fnc_returnConfigEntry);
-
-    private _mainAction = [
-        "ACE_MainActions",
-        "Interactions",
-        "",
-        {},
-        {true},
-        {[]},
-        [],
-        _interactPoint
-    ] call ace_interact_menu_fnc_createAction;
-
-    [
-        configName _x,
-        0,
-        [],
-        _mainAction,
-        true
-    ] call ace_interact_menu_fnc_addActionToClass;
-
-    private _loadAction = [
-        QGVAR(loadAction),
-        "load on vehicle",
-        "a3\ui_f\data\IGUI\Cfg\Actions\loadVehicle_ca.paa",
-        FUNC(interact_loadAction),
-        FUNC(interact_loadCondition),
-        FUNC(interact_loadChildren),
-        [],
-        _interactPoint
-    ] call ace_interact_menu_fnc_createAction;
-    [
-        configName _x,
-        0,
-        ["ACE_MainActions"],
-        _loadAction,
-        true
-    ] call ace_interact_menu_fnc_addActionToClass;
-
-} forEach ([] call FUNC(getSupportedAnimalConfigs));
-
-{
     private _unloadActionPoint = ([_x >> "GRAD_AnimalTransport", "unloadActionPoint", [0, 0, 0]] call BIS_fnc_returnConfigEntry);
     private _positionedUnloadAction = [
         QGVAR(unloadAction),

--- a/addons/animalTransport/functions/fnc_findSuitableVehicle.sqf
+++ b/addons/animalTransport/functions/fnc_findSuitableVehicle.sqf
@@ -11,10 +11,7 @@ if (isNull _animal) exitWith {
 
 TRACE_1("findSuitableVehicle: %1", _animal);
 
-// configured vehicle classes
-_possibleVehicleClasses = [] call FUNC(getSupportedCarConfigs);
-_possibleVehicleClassNames = _possibleVehicleClasses apply { configName _x};
-private _candidates = nearestObjects [_animal, _possibleVehicleClassNames, GVAR(loadingRange), false];
+private _candidates = [_animal] call FUNC(findTransportsInLoadingRange);
 
 private _foundIdx = _candidates findIf {
     !(isNull ([_x, typeOf _animal] call FUNC(findSuitableSpace)));

--- a/addons/animalTransport/functions/fnc_findSuitableVehicles.sqf
+++ b/addons/animalTransport/functions/fnc_findSuitableVehicles.sqf
@@ -9,22 +9,15 @@ params [
 
 assert(!(isNull _animal));
 
-private _animalClass = typeOf _animal;
-
-// configured vehicle classes
-private _possibleVehicleClasses = [] call FUNC(getSupportedCarConfigs);
-_possibleVehicleClasses = _possibleVehicleClasses apply { configName _x };
+private _candidates = [_animal] call FUNC(findTransportsInLoadingRange);
 
 private _result = [] call cba_fnc_hashCreate;
-
-private _nearVehicles = nearestObjects [_animal, _possibleVehicleClasses, GVAR(loadingRange), false];
-
 {
     [
         _result,
         _x,
         ([_x, typeOf _animal] call FUNC(findSuitableSpaces))
     ] call cba_fnc_hashSet;
-} forEach _nearVehicles;
+} forEach _candidates;
 
 _result

--- a/addons/animalTransport/functions/fnc_findTransportsInLoadingRange.sqf
+++ b/addons/animalTransport/functions/fnc_findTransportsInLoadingRange.sqf
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+/* return transport vehicles with a (un)loading point close enough to the passed animal */
+
+params [
+    ["_animal", objNull]
+];
+
+private _possibleVehicleClasses = [] call FUNC(getSupportedCarConfigs); // configured vehicle classes
+private _possibleVehicleClassNames = _possibleVehicleClasses apply { configName _x};
+(nearestObjects [_animal, _possibleVehicleClassNames, GVAR(loadingRange) + 10, false]) select {
+    private _unloadPoint = [
+        [_x] call FUNC(getCustomConfig),
+        "unloadPoint",
+        [0, 0, 0]
+    ] call BIS_fnc_returnConfigEntry;
+
+    _animal distance (_unloadPoint vectorAdd (getPos _x)) < GVAR(loadingRange);
+}

--- a/addons/animalTransport/functions/fnc_interact_loadChildren.sqf
+++ b/addons/animalTransport/functions/fnc_interact_loadChildren.sqf
@@ -17,9 +17,9 @@ private _spaces = [_target] call FUNC(findSuitableVehicles);
 
             [QGVAR(vehicle_loadAnimal), [_vehicle, _target], _vehicle] call CBA_fnc_targetEvent;
         },
-        {true},
+        {params ["", "", "_args"]; _args params ["","_vehicleSpaces"]; _vehicleSpaces > 0},
         FUNC(interact_loadChildrenSpaces),
-        [_vehicle]
+        [_vehicle, count _vehicleSpaces]
     ] call ace_interact_menu_fnc_createAction;
 
     [

--- a/addons/animalTransport/functions/fnc_interact_loadCondition.sqf
+++ b/addons/animalTransport/functions/fnc_interact_loadCondition.sqf
@@ -4,5 +4,8 @@ params ["_target"];
 
 TRACE_1("interact_loadCondition with %1", _target);
 
-(isNull (attachedTo _target)) &&
-!(isNull ([_target] call FUNC(findSuitableVehicle)))
+if (isNull (attachedTo _target)) then {
+    !(isNull ([_target] call FUNC(findSuitableVehicle)))
+} else {
+    false
+};

--- a/addons/animalTransport/functions/fnc_vehicle_loadAnimal.sqf
+++ b/addons/animalTransport/functions/fnc_vehicle_loadAnimal.sqf
@@ -19,6 +19,7 @@ private _necessarySeats = [_space, "cargoIndices", []] call BIS_fnc_returnConfig
 
 
 private _seatOffset = [_space, "offset", [0, 0, 0]] call BIS_fnc_returnConfigEntry;
+_animal setVariable ["ace_dragging_canCarry", false, true];
 _animal attachTo [_vehicle, _seatOffset];
 
 private _dir = [_space, "dir", 0] call BIS_fnc_returnConfigEntry;

--- a/addons/animalTransport/functions/fnc_vehicle_unloadAnimalDetach.sqf
+++ b/addons/animalTransport/functions/fnc_vehicle_unloadAnimalDetach.sqf
@@ -13,4 +13,5 @@ private _unloadPoint = [
 
 _animal attachTo [_vehicle, _unloadPoint];
 detach _animal;
+_animal setVariable ["ace_dragging_canCarry", true, true];
 ["ace_common_setDir", [_animal, (getDir _vehicle) - 180], _animal] call CBA_fnc_targetEvent;


### PR DESCRIPTION
* actions are added via config which fixes interaction point appearing twice (which was caused by ace_dragging doing its own thing separately)
* dont show vehicle (even if suitable) if there's no space left on it
* animals can be loaded if in range of the *(un)load point* instead of the center of the vehicle model
* ensure you can not directly pick off animal from vehicles  - avoid bug where vehicle seats do not get unlocked even if no animal is present

