### PR TITLE
Fix output modname 

### DIFF
--- a/hemtt.toml
+++ b/hemtt.toml
@@ -1,4 +1,5 @@
 name = "Gruppe Adler Mod"
+modname = "gruppe_adler_mod"
 prefix = "grad"
 author = "Gruppe Adler"
 files = [


### PR DESCRIPTION
This PR will change the name of the release build from `@grad` to `@gruppe_adler_mod`.