### PR TITLE
Nerf offroading

### DIFF
--- a/addons/offroadNerf/$PBOPREFIX$
+++ b/addons/offroadNerf/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\grad\addons\nerfOffroad

--- a/addons/offroadNerf/CfgEventHandlers.hpp
+++ b/addons/offroadNerf/CfgEventHandlers.hpp
@@ -1,0 +1,18 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+        clientInit = QUOTE(call COMPILE_FILE(XEH_postClientInit));
+    };
+};

--- a/addons/offroadNerf/README.md
+++ b/addons/offroadNerf/README.md
@@ -1,0 +1,8 @@
+### nerfOffroad
+
+Ensure vehicles feel the pain when leaving the pavement.
+
+#### Maintainer(s)
+
+* Fusselwurm
+

--- a/addons/offroadNerf/XEH_PREP.hpp
+++ b/addons/offroadNerf/XEH_PREP.hpp
@@ -1,0 +1,1 @@
+PREP(limitOffroadSpeed);

--- a/addons/offroadNerf/XEH_postClientInit.sqf
+++ b/addons/offroadNerf/XEH_postClientInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/offroadNerf/XEH_postInit.sqf
+++ b/addons/offroadNerf/XEH_postInit.sqf
@@ -1,0 +1,1 @@
+#include "script_component.hpp"

--- a/addons/offroadNerf/XEH_postInit.sqf
+++ b/addons/offroadNerf/XEH_postInit.sqf
@@ -1,1 +1,3 @@
 #include "script_component.hpp"
+
+[] call FUNC(limitOffroadSpeed);

--- a/addons/offroadNerf/XEH_preInit.sqf
+++ b/addons/offroadNerf/XEH_preInit.sqf
@@ -1,0 +1,9 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+PREP_RECOMPILE_START;
+#include "XEH_PREP.hpp"
+PREP_RECOMPILE_END;
+
+ADDON = true;

--- a/addons/offroadNerf/XEH_preStart.sqf
+++ b/addons/offroadNerf/XEH_preStart.sqf
@@ -1,0 +1,2 @@
+#include "script_component.hpp"
+#include "XEH_PREP.hpp"

--- a/addons/offroadNerf/config.cpp
+++ b/addons/offroadNerf/config.cpp
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+	class ADDON {
+		author = "$STR_grad_Author";
+		name = QUOTE(ADDON);
+		url = "$STR_grad_URL";
+		requiredAddons[] = {
+			"grad_main"
+		};
+		units[] = {};
+		weapons[] = {};
+		VERSION_CONFIG;
+		authors[] = {"Fusselwurm"};
+	};
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/offroadNerf/functions/fn_limitOffroadSpeed.sqf
+++ b/addons/offroadNerf/functions/fn_limitOffroadSpeed.sqf
@@ -1,0 +1,71 @@
+/**
+ * Wheeled vehicles go over rough ground as if it were concrete.
+ * No more!
+ * Run this function ONCE to periodically reduce speed according to surface.
+ */
+
+_interval = 0.5; // how many seconds should speed be checked
+_minSpeed = 5; // dont check below this speed in km/h
+
+_vehicleNerfLoop = {
+	_minSpeed = (param [0] select 0);
+
+	_frictionMap = [
+		[
+			["#GdtStratisConcrete", 1],
+			["#GdtStratisDryGrass", 0.8],
+			["#GdtStratisGreenGrass", 0.8],
+			["#GdtStratisRocky", 0.7],
+			["#GdtStratisForestPine", 0.6],
+			["#GdtStratisBeach", 0.8],
+			["#GdtStratisDirt", 0.8],
+			["#GdtStratisThistles", 0.7],
+			["#GdtVRsurface01", 1],
+			["#GdtDirt", 0.8],
+			["#GdtGrassGreen", 0.8],
+			["#GdtGrassDry", 0.8],
+			["#GdtSoil", 0.8],
+			["#GdtThorn", 0.7],
+			["#GdtStony", 0.6],
+			["#GdtConcrete", 1],
+			["#GdtMarsh", 0.5],
+			["#GdtBeach", 0.7],
+			["#GdtSeabed", 0.9],
+			["#GdtDead", 1]
+		],
+		1
+	] call CBA_fnc_hashCreate;
+
+	_isEligibleVehicle = {
+		(local _this) && (_this isKindOf "Car") && !(_this isKindOf "Wheeled_APC_F");
+	};
+
+	_isOffRoad = {
+		! (isOnRoad (position _this));
+	};
+
+	_isFastEnough = {
+		(speed _this) > _minSpeed;
+	};
+
+	_setSpeedNerf = {
+		_velocity = velocity _this;
+		_pos = position _this;
+
+		_frictionSpeedFactor = [_frictionMap, surfaceType _pos, 1] call CBA_fnc_hashGet;
+		if (_frictionSpeedFactor != 1) then {
+			_reducedVelocity = [_velocity, _frictionSpeedFactor] call CBA_fnc_scaleVect;
+			_this setVelocity _reducedVelocity;
+		};
+	};
+
+	_vehicles = vehicles;
+	{
+		_vehicles = [_vehicles, _x] call CBA_fnc_select;
+	} forEach [_isEligibleVehicle, _isFastEnough, _isOffRoad];
+
+	{_x call _setSpeedNerf}  forEach _vehicles;
+};
+
+
+[_vehicleNerfLoop, _interval, [_minSpeed]] call CBA_fnc_addPerFrameHandler;

--- a/addons/offroadNerf/functions/script_component.hpp
+++ b/addons/offroadNerf/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "..\script_component.hpp"

--- a/addons/offroadNerf/script_component.hpp
+++ b/addons/offroadNerf/script_component.hpp
@@ -1,0 +1,8 @@
+#define COMPONENT nerfOffroad
+
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#include "\x\grad\addons\main\script_mod.hpp"
+#include "\x\grad\addons\main\script_macros.hpp"


### PR DESCRIPTION
*as discussed in https://github.com/gruppe-adler/TvT_GTV.lythium/issues/16*

nerf offroading:

Many vehicles in Arma mostly do not sufficiently feel what it's like to go offroad. 

This addon aims to punish cars & bikes for going offroad. 

We'll need to take a lot of stuff into consideration here:
* some islands already provide tough going offroad (example: VT7)
* some vehicles are very slow from the get-go (example: RDS Civ vics)
* some vehicles should not be impacted much (example: APCs)
