### PR TITLE
remove implementation of CBA_fnc_hashValues

### DIFF
--- a/addons/animalTransport/XEH_postInit.sqf
+++ b/addons/animalTransport/XEH_postInit.sqf
@@ -1,9 +1,5 @@
 #include "script_component.hpp"
 
-if (isNil "CBA_fnc_hashValues") then { // https://github.com/CBATeam/CBA_A3/pull/1350
-    CBA_fnc_hashValues = {+((_this#0) select 2)};
-};
-
 [QGVAR(vehicle_loadAnimal), {
     scriptName QGVAR(vehicle_loadAnimal);
     _this call FUNC(vehicle_loadAnimal);


### PR DESCRIPTION
remove unnecessary implementation of CBA_fnc_hashValues , see https://github.com/CBATeam/CBA_A3/pull/1350 which has been merged & released with CBA-3.15.2